### PR TITLE
Remove players from lobby on quit tmmn

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -92,18 +92,18 @@ public class LobbyController {
         }
     }
 
-    @DeleteMapping("/lobbies/{code}/players/{id}")
+    @DeleteMapping("/lobbies/{lobbyCode}/players/{playerId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removePlayerFromLobby(@PathVariable String code, @PathVariable String id, @RequestHeader String token) {
+    public void removePlayerFromLobby(@PathVariable String lobbyCode, @PathVariable String playerId, @RequestHeader String playerToken) {
         // check inputs
-        if (token == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "include player token in your request header as token");
+        if (playerToken == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "include player token in your request header as playerToken");
         }
-        long lobbyCodeLong = parseLobbyCode(code);
-        long playerIdLong = parseId(id);
+        long lobbyCodeLong = parseLobbyCode(lobbyCode);
+        long playerIdLong = parseId(playerId);
 
         // get and check player
-        Player player = playerService.checkToken(token);
+        Player player = playerService.checkToken(playerToken);
         if (player.getId() != playerIdLong) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     String.format("Your player has id %d, but you tried to remove player with id %d", player.getId(), playerIdLong));

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerJoinedDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerJoinedDTO.java
@@ -4,6 +4,8 @@ public class PlayerJoinedDTO {
 
     private String playerToken;
 
+    private long playerId;
+
     private LobbyGetDTO lobby;
 
     public String getPlayerToken() {
@@ -12,6 +14,14 @@ public class PlayerJoinedDTO {
 
     public void setPlayerToken(String playerToken) {
         this.playerToken = playerToken;
+    }
+
+    public long getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(long playerId) {
+        this.playerId = playerId;
     }
 
     public LobbyGetDTO getLobby() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -54,6 +54,7 @@ public interface DTOMapper {
     LobbyGetDTO convertEntityToLobbyGetDTO(Lobby lobby);
 
     @Mapping(source = "token", target = "playerToken")
+    @Mapping(source = "id", target = "playerId")
     @Mapping(source = "lobby", target = "lobby")
     PlayerJoinedDTO convertEntityToPlayerJoinedDTO(Player player);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -96,7 +96,7 @@ public class LobbyService {
         }
         lobby.setPlayers(null);
         lobbyRepository.delete(lobby);
-        log.debug("successfully deleted player {}", lobby);
+        log.debug("successfully deleted lobby {}", lobby);
     }
 
     private long generateLobbyCode() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -26,9 +26,12 @@ public class LobbyService {
 
     private final LobbyRepository lobbyRepository;
 
+    private final PlayerService playerService;
+
     @Autowired
-    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository) {
+    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository, PlayerService playerService) {
         this.lobbyRepository = lobbyRepository;
+        this.playerService = playerService;
     }
 
     public List<Lobby> getPublicLobbies() {
@@ -89,12 +92,11 @@ public class LobbyService {
             lobby.setOwner(null);
         }
         if (lobby.getPlayers() != null) {
-            for (Player p : lobby.getPlayers()) {
-                p.setLobby(null);
+            List<Player> playerList = lobby.getPlayers();
+            for (int i = playerList.toArray().length-1; i>=0; i--) {
+                playerService.removePlayer(playerList.get(i));
             }
-            lobby.setPlayers(null);
         }
-        lobby.setPlayers(null);
         lobbyRepository.delete(lobby);
         log.debug("successfully deleted lobby {}", lobby);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -83,6 +83,22 @@ public class LobbyService {
         return player;
     }
 
+    public void removeLobby(Lobby lobby) {
+        if (lobby.getOwner() != null) {
+            lobby.getOwner().setOwnedLobby(null);
+            lobby.setOwner(null);
+        }
+        if (lobby.getPlayers() != null) {
+            for (Player p : lobby.getPlayers()) {
+                p.setLobby(null);
+            }
+            lobby.setPlayers(null);
+        }
+        lobby.setPlayers(null);
+        lobbyRepository.delete(lobby);
+        log.debug("successfully deleted player {}", lobby);
+    }
+
     private long generateLobbyCode() {
         long code = ThreadLocalRandom.current().nextLong(1000, 10000);
         while (lobbyRepository.existsByCode(code)) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlayerService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlayerService.java
@@ -1,0 +1,54 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Player;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.PlayerRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class PlayerService {
+
+    private final Logger log = LoggerFactory.getLogger(LobbyService.class);
+
+    private final PlayerRepository playerRepository;
+
+    @Autowired
+    public PlayerService(@Qualifier("playerRepository") PlayerRepository playerRepository) {
+        this.playerRepository = playerRepository;
+    }
+
+    public Player checkToken(String token) {
+        Player foundPlayer = playerRepository.findByToken(token);
+        if (foundPlayer == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "No player found with this token");
+        }
+        log.debug("found the player for the provided token: {}", foundPlayer);
+        return foundPlayer;
+    }
+
+    public void removePlayer(Player player) {
+        if (player.getUser() != null) {
+            User user = player.getUser();
+            user.setPlayer(null);
+            player.setUser(null);
+        }
+        if (player.getOwnedLobby() != null) {
+            player.getOwnedLobby().setOwner(null);
+            player.setOwnedLobby(null);
+        }
+        player.getLobby().getPlayers().remove(player);
+        player.setLobby(null);
+        playerRepository.delete(player);
+        log.debug("successfully deleted player {}", player);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -388,14 +388,14 @@ public class LobbyControllerTest {
         Mockito.doNothing().when(playerService).removePlayer(Mockito.any());
 
         // when
-        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players")
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/6")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("token", "234");
 
         //then
         mockMvc.perform(deleteRequest)
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         Mockito.verify(playerService, Mockito.times(1)).checkToken(Mockito.any());
         Mockito.verify(playerService, Mockito.times(1)).removePlayer(Mockito.any());
@@ -423,21 +423,19 @@ public class LobbyControllerTest {
         testLobby.setPlayers(List.of(testPlayer1, testPlayer2));
 
         given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
-        Mockito.doNothing().when(playerService).removePlayer(Mockito.any());
         Mockito.doNothing().when(lobbyService).removeLobby(Mockito.any());
 
         // when
-        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players")
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/5")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("token", "123");
 
         //then
         mockMvc.perform(deleteRequest)
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         Mockito.verify(playerService, Mockito.times(1)).checkToken(Mockito.any());
-        Mockito.verify(playerService, Mockito.times(2)).removePlayer(Mockito.any());
         Mockito.verify(lobbyService, Mockito.times(1)).removeLobby(Mockito.any());
     }
 
@@ -460,7 +458,7 @@ public class LobbyControllerTest {
         given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
-        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players")
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/5")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON);
 
@@ -488,7 +486,7 @@ public class LobbyControllerTest {
         given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
-        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/4541/players")
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/4541/players/5")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("token", "123");
@@ -517,7 +515,65 @@ public class LobbyControllerTest {
         given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
-        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/four23one/players")
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/four23one/players/5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("token", "123");
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void removePlayer_invalidId_throwsNotFoundException() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/53")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("token", "123");
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void removePlayer_badlyFormattedId_throwsBadRequestException() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/five")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("token", "123");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -30,8 +30,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -362,6 +361,170 @@ public class LobbyControllerTest {
 
         //then
         mockMvc.perform(postRequest).andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void removePlayerNotOwner_validInputs_success() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        Player testPlayer2 = new Player("234", "testplayer2", testLobby);
+        testPlayer2.setId(6L);
+        testPlayer2.setPoints(54);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testPlayer2.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1, testPlayer2));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer2);
+        Mockito.doNothing().when(playerService).removePlayer(Mockito.any());
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("token", "234");
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isOk());
+
+        Mockito.verify(playerService, Mockito.times(1)).checkToken(Mockito.any());
+        Mockito.verify(playerService, Mockito.times(1)).removePlayer(Mockito.any());
+    }
+
+    @Test
+    public void removePlayerOwner_validInputs_success() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        Player testPlayer2 = new Player("234", "testplayer2", testLobby);
+        testPlayer2.setId(6L);
+        testPlayer2.setPoints(54);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testPlayer2.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1, testPlayer2));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        Mockito.doNothing().when(playerService).removePlayer(Mockito.any());
+        Mockito.doNothing().when(lobbyService).removeLobby(Mockito.any());
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("token", "123");
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isOk());
+
+        Mockito.verify(playerService, Mockito.times(1)).checkToken(Mockito.any());
+        Mockito.verify(playerService, Mockito.times(2)).removePlayer(Mockito.any());
+        Mockito.verify(lobbyService, Mockito.times(1)).removeLobby(Mockito.any());
+    }
+
+    @Test
+    public void removePlayer_noToken_throwsBadRequestError() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON);
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void removePlayer_invalidCode_throwsBadRequestError() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/4541/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("token", "123");
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void removePlayer_badlyFormattedCode_throwsBadRequestError() throws Exception {
+        // given
+        Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
+        testLobby.setPublicAccess(true);
+
+        Player testPlayer1 = new Player("123", "testplayer", testLobby);
+        testPlayer1.setId(5L);
+        testPlayer1.setPoints(32);
+
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testLobby.setPlayers(List.of(testPlayer1));
+
+        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/four23one/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("token", "123");
+
+        //then
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isBadRequest());
     }
 
     /**

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -391,7 +391,7 @@ public class LobbyControllerTest {
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/6")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("token", "234");
+                .header("playerToken", "234");
 
         //then
         mockMvc.perform(deleteRequest)
@@ -429,7 +429,7 @@ public class LobbyControllerTest {
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/5")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("token", "123");
+                .header("playerToken", "123");
 
         //then
         mockMvc.perform(deleteRequest)
@@ -489,7 +489,7 @@ public class LobbyControllerTest {
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/4541/players/5")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("token", "123");
+                .header("playerToken", "123");
 
         //then
         mockMvc.perform(deleteRequest)
@@ -518,7 +518,7 @@ public class LobbyControllerTest {
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/four23one/players/5")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("token", "123");
+                .header("playerToken", "123");
 
         //then
         mockMvc.perform(deleteRequest)
@@ -547,7 +547,7 @@ public class LobbyControllerTest {
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/53")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("token", "123");
+                .header("playerToken", "123");
 
         //then
         mockMvc.perform(deleteRequest)
@@ -576,7 +576,7 @@ public class LobbyControllerTest {
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/five")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("token", "123");
+                .header("playerToken", "123");
 
         //then
         mockMvc.perform(deleteRequest)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -8,6 +8,7 @@ import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPostDTO;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.PlayerService;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,6 +51,9 @@ public class LobbyControllerTest {
 
     @MockBean
     private UserService userService;
+
+    @MockBean
+    private PlayerService playerService;
 
     @Test
     public void givenLobbies_whenGetLobbies_thenReturnJsonArray() throws Exception {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -103,4 +103,9 @@ public class LobbyServiceIntegrationTest {
         // when then
         assertThrows(ResponseStatusException.class, () -> lobbyService.joinLobbyFromUser(testUser, 234));
     }
+
+    @Test
+    public void removeLobby_success() {
+        // TODO: to be implemented
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
@@ -12,6 +13,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -106,6 +110,23 @@ public class LobbyServiceIntegrationTest {
 
     @Test
     public void removeLobby_success() {
-        // TODO: to be implemented
+        assertNull(lobbyRepository.findByCode(123));
+
+        Lobby testLobby = new Lobby(123, "this is a new lobby");
+        testLobby.setPublicAccess(true);
+
+        Player player1 = new Player("123", "asdf", testLobby);
+        Player player2 = new Player("234", "jklö", testLobby);
+        player1.setOwnedLobby(testLobby);
+        testLobby.setOwner(player1);
+
+        testLobby.setPlayers(new ArrayList<>(Arrays.asList(player1, player2)));
+
+        Lobby savedLobby = lobbyRepository.saveAndFlush(testLobby);
+
+        assertEquals(testLobby.getName(), savedLobby.getName());
+
+        lobbyService.removeLobby(savedLobby);
+        assertNull(lobbyRepository.findByCode(123));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -35,6 +35,9 @@ public class LobbyServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private PlayerService playerService;
+
     @InjectMocks
     private LobbyService lobbyService;
 
@@ -152,6 +155,18 @@ public class LobbyServiceTest {
 
     @Test
     public void removeLobby_success() {
-        // TODO: to be implemented
+        // given
+        Player testPlayer2 = new Player("234", "testPlayer2", testLobby);
+        testLobby.getPlayers().add(testPlayer2);
+
+        Mockito.doNothing().when(lobbyRepository).delete(Mockito.any());
+        Mockito.doNothing().when(playerService).removePlayer(Mockito.any());
+
+        // when
+        lobbyService.removeLobby(testLobby);
+
+        // then
+        Mockito.verify(playerService, Mockito.times(2)).removePlayer(Mockito.any());
+        Mockito.verify(lobbyRepository, Mockito.times(1)).delete(Mockito.any());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -149,4 +149,9 @@ public class LobbyServiceTest {
 
         assertThrows(ResponseStatusException.class, () -> lobbyService.joinLobbyFromUser(testUser, testLobby.getCode()));
     }
+
+    @Test
+    public void removeLobby_success() {
+        // TODO: to be implemented
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceIntegrationTest.java
@@ -1,0 +1,42 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+
+import ch.uzh.ifi.hase.soprafs24.repository.PlayerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@WebAppConfiguration
+@SpringBootTest
+public class PlayerServiceIntegrationTest {
+
+    @Qualifier("playerRepository")
+    @Autowired
+    PlayerRepository playerRepository;
+
+    @Autowired
+    PlayerService playerService;
+
+    @BeforeEach
+    public void setup() {
+        playerRepository.deleteAll();
+    }
+
+    @Test
+    public void checkToken_validInput_success() {
+        // TODO: to be implemented
+    }
+
+    @Test
+    public void checkToken_invalidToken_throwsNotFoundException() {
+        // TODO: to be implemented
+    }
+
+    @Test
+    public void removePlayer_success() {
+        // TODO: to be implemented
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceIntegrationTest.java
@@ -1,13 +1,25 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.Player;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs24.repository.PlayerRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @WebAppConfiguration
 @SpringBootTest
@@ -16,6 +28,14 @@ public class PlayerServiceIntegrationTest {
     @Qualifier("playerRepository")
     @Autowired
     PlayerRepository playerRepository;
+
+    @Qualifier("userRepository")
+    @Autowired
+    UserRepository userRepository;
+
+    @Qualifier("lobbyRepository")
+    @Autowired
+    LobbyRepository lobbyRepository;
 
     @Autowired
     PlayerService playerService;
@@ -27,16 +47,51 @@ public class PlayerServiceIntegrationTest {
 
     @Test
     public void checkToken_validInput_success() {
-        // TODO: to be implemented
+        Player testPlayer = new Player("234", "test", null);
+        playerRepository.save(testPlayer);
+
+        Player checkedPlayer = playerService.checkToken(testPlayer.getToken());
+        assertEquals(testPlayer.getToken(), checkedPlayer.getToken());
+        assertEquals(testPlayer.getPoints(), checkedPlayer.getPoints());
+        assertEquals(testPlayer.getName(), checkedPlayer.getName());
     }
 
     @Test
     public void checkToken_invalidToken_throwsNotFoundException() {
-        // TODO: to be implemented
+        Player testPlayer = new Player("345", "tester", null);
+        playerRepository.save(testPlayer);
+
+        assertThrows(ResponseStatusException.class, () -> playerService.checkToken(testPlayer.getToken()+"23"));
     }
 
     @Test
     public void removePlayer_success() {
-        // TODO: to be implemented
+        assertNull(playerRepository.findByToken("678"));
+
+        User testUser = new User();
+        testUser.setUsername("testUser");
+        testUser.setPassword("testPassword");
+        testUser.setToken("678");
+        testUser.setStatus(UserStatus.OFFLINE);
+        User savedUser = userRepository.saveAndFlush(testUser);
+
+        Lobby testLobby = new Lobby(123, "this is a new lobby");
+        testLobby.setPublicAccess(true);
+
+        Player player1 = new Player("123", "asdf", testLobby);
+        player1.setOwnedLobby(testLobby);
+        testLobby.setOwner(player1);
+        testLobby.setPlayers(new ArrayList<>(Arrays.asList(player1)));
+
+        Lobby savedLobby = lobbyRepository.saveAndFlush(testLobby);
+
+        savedLobby.getOwner().setUser(savedUser);
+        savedUser.setPlayer(savedLobby.getOwner());
+
+        assertEquals(testLobby.getName(), savedLobby.getName());
+
+        playerService.removePlayer(player1);
+
+        assertNull(playerRepository.findByToken("678"));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceTest.java
@@ -1,0 +1,88 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.constant.GameMode;
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.Player;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.PlayerRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class PlayerServiceTest {
+
+    @Mock
+    private PlayerRepository playerRepository;
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PlayerService playerService;
+
+    private User testUser1;
+
+    private User testUser2;
+
+    private Player testPlayer1;
+
+    private Player testPlayer2;
+
+    private Lobby testLobby;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        testLobby = new Lobby(1234, "test Lobby");
+        testLobby.setMode(GameMode.STANDARD);
+
+        testPlayer1 = new Player("123", "testplayer", null);
+        testPlayer1.setPoints(32);
+        // no value for AvailableWords set
+
+        testUser1 = new User();
+        testUser1.setId(1L);
+        testUser1.setPassword("testPassword");
+        testUser1.setUsername("firstname@lastname");
+        testUser1.setStatus(UserStatus.OFFLINE);
+        testUser1.setToken("1");
+
+        testPlayer2 = new Player("234", "testplayer2", null);
+        testPlayer2.setPoints(12);
+        // no value for AvailableWords set
+
+//        testUser.setPlayer(testPlayer);
+//        testPlayer.setUser(testUser);
+//
+//        testLobby.setOwner(testPlayer);
+//        testPlayer.setOwnedLobby(testLobby);
+//
+//        testPlayer.setLobby(testLobby);
+//        testLobby.setPlayers(new ArrayList<>(Arrays.asList(testPlayer)));
+    }
+
+    @Test
+    public void checkToken_validInput_success() {
+        // TODO: to be implemented
+    }
+
+    @Test
+    public void checkToken_invalidToken_throwsNotFoundException() {
+        // TODO: to be implemented
+    }
+
+    @Test
+    public void removePlayer_success() {
+        // TODO: to be implemented
+    }
+
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceTest.java
@@ -5,32 +5,29 @@ import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
-import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs24.repository.PlayerRepository;
-import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PlayerServiceTest {
 
     @Mock
     private PlayerRepository playerRepository;
 
-    @Mock
-    private LobbyRepository lobbyRepository;
-
-    @Mock
-    private UserRepository userRepository;
-
     @InjectMocks
     private PlayerService playerService;
 
     private User testUser1;
-
-    private User testUser2;
 
     private Player testPlayer1;
 
@@ -58,31 +55,41 @@ public class PlayerServiceTest {
 
         testPlayer2 = new Player("234", "testplayer2", null);
         testPlayer2.setPoints(12);
-        // no value for AvailableWords set
 
-//        testUser.setPlayer(testPlayer);
-//        testPlayer.setUser(testUser);
-//
-//        testLobby.setOwner(testPlayer);
-//        testPlayer.setOwnedLobby(testLobby);
-//
-//        testPlayer.setLobby(testLobby);
-//        testLobby.setPlayers(new ArrayList<>(Arrays.asList(testPlayer)));
+        testLobby.setOwner(testPlayer1);
+        testPlayer1.setOwnedLobby(testLobby);
+
+        testPlayer1.setLobby(testLobby);
+        testPlayer2.setLobby(testLobby);
+        testLobby.setPlayers(new ArrayList<>(Arrays.asList(testPlayer1, testPlayer2)));
     }
 
     @Test
     public void checkToken_validInput_success() {
-        // TODO: to be implemented
+        Mockito.when(playerRepository.findByToken(Mockito.anyString())).thenReturn(testPlayer1);
+
+        Player checkedPlayer = playerService.checkToken(testPlayer1.getToken());
+        assertEquals(testPlayer1.getId(), checkedPlayer.getId());
+        assertEquals(testPlayer1.getName(), checkedPlayer.getName());
+        assertEquals(testPlayer1.getPoints(), checkedPlayer.getPoints());
     }
 
     @Test
     public void checkToken_invalidToken_throwsNotFoundException() {
-        // TODO: to be implemented
+        Mockito.when(playerRepository.findByToken(Mockito.anyString())).thenReturn(null);
+
+        assertThrows(ResponseStatusException.class, () -> playerService.checkToken(Mockito.anyString()));
     }
 
     @Test
     public void removePlayer_success() {
-        // TODO: to be implemented
-    }
+        // given
+        Mockito.doNothing().when(playerRepository).delete(Mockito.any());
 
+        // when
+        playerService.removePlayer(testPlayer1);
+
+        // then
+        Mockito.verify(playerRepository, Mockito.times(1)).delete(Mockito.any());
+    }
 }


### PR DESCRIPTION
Introduces DELETE `/lobbies/{code}/players` endpoint. Provide player token as `token` in header and use the correct lobby code in path. Players just get deleted and players that are lobby owners also delete the lobby and all players that where in it. 
Includes tests and closes #87 