### PR TITLE
Client server gameplay interaction

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyGetDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPostDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.PlayerGetDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.PlayerJoinedDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
@@ -88,6 +89,12 @@ public class LobbyController {
         else {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "joining lobby as anonymous user not supported, please supply userToken as header field");
         }
+    }
+
+    @PutMapping("/lobbies/{lobbyCode}/players/{playerId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void play(@PathVariable String lobbyCode, @PathVariable String playerId, @RequestHeader String playerToken) {
+        Player player = getAuthenticatedPlayer(lobbyCode, playerId, playerToken);
     }
 
     @DeleteMapping("/lobbies/{lobbyCode}/players/{playerId}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -3,11 +3,10 @@ package ch.uzh.ifi.hase.soprafs24.controller;
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyGetDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPostDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.PlayerGetDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.PlayerJoinedDTO;
+import ch.uzh.ifi.hase.soprafs24.entity.Word;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.*;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.service.GameService;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.service.PlayerService;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
@@ -31,11 +30,13 @@ public class LobbyController {
     private final UserService userService;
 
     private final PlayerService playerService;
+    private final GameService gameService;
 
-    LobbyController(LobbyService lobbyService, UserService userService, PlayerService playerService) {
+    LobbyController(LobbyService lobbyService, UserService userService, PlayerService playerService, GameService gameService) {
         this.lobbyService = lobbyService;
         this.userService = userService;
         this.playerService = playerService;
+        this.gameService = gameService;
     }
 
     @GetMapping("/lobbies")
@@ -93,8 +94,11 @@ public class LobbyController {
 
     @PutMapping("/lobbies/{lobbyCode}/players/{playerId}")
     @ResponseStatus(HttpStatus.OK)
-    public void play(@PathVariable String lobbyCode, @PathVariable String playerId, @RequestHeader String playerToken) {
+    public PlayerPlayedDTO play(@PathVariable String lobbyCode, @PathVariable String playerId,
+                                @RequestHeader String playerToken, @RequestBody List<Word> words) {
         Player player = getAuthenticatedPlayer(lobbyCode, playerId, playerToken);
+        gameService.play(player, words);
+        return DTOMapper.INSTANCE.convertEntityToPlayerPlayedDTO(player);
     }
 
     @DeleteMapping("/lobbies/{lobbyCode}/players/{playerId}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Combination.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Combination.java
@@ -1,8 +1,11 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
+import org.hibernate.proxy.HibernateProxy;
+
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Objects;
 
 
 @Entity
@@ -35,6 +38,25 @@ public class Combination implements Serializable {
         this.word1 = word1;
         this.word2 = word2;
         this.result = result;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Combination that = (Combination) o;
+        return Objects.equals(getId(), that.getId()) &&
+               Objects.equals(getWord1(), that.getWord1()) &&
+               Objects.equals(getWord2(), that.getWord2()) &&
+               Objects.equals(getResult(), that.getResult());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
 
     public Long getId() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -27,16 +27,16 @@ public class Lobby implements Serializable {
     private String name;
 
     @Column(nullable = false)
-    private Boolean publicAccess;
+    private Boolean publicAccess = true;
 
     @Column
     private LocalDateTime startTime;
 
     @Column(nullable = false)
-    private LobbyStatus status;
+    private LobbyStatus status = LobbyStatus.PREGAME;
 
     @Column
-    private GameMode mode;
+    private GameMode mode = GameMode.STANDARD;
 
     @OneToOne(mappedBy = "ownedLobby")
     private Player owner;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -2,12 +2,14 @@ package ch.uzh.ifi.hase.soprafs24.entity;
 
 import ch.uzh.ifi.hase.soprafs24.constant.GameMode;
 import ch.uzh.ifi.hase.soprafs24.constant.LobbyStatus;
+import org.hibernate.proxy.HibernateProxy;
 
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Internal Lobby Representation
@@ -51,6 +53,29 @@ public class Lobby implements Serializable {
         this.name = name;
         this.publicAccess = false;
         this.status = LobbyStatus.PREGAME;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Lobby that = (Lobby) o;
+        return Objects.equals(getCode(), that.getCode()) &&
+               Objects.equals(getName(), that.getName()) &&
+               Objects.equals(getPublicAccess(), that.getPublicAccess()) &&
+               Objects.equals(getStartTime(), that.getStartTime()) &&
+               Objects.equals(getStatus(), that.getStatus()) &&
+               Objects.equals(getMode(), that.getMode()) &&
+               Objects.equals(getOwner(), that.getOwner()) &&
+               Objects.equals(getPlayers(), that.getPlayers());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
 
     public long getCode() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
@@ -5,8 +5,7 @@ import org.hibernate.proxy.HibernateProxy;
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.Objects;
 
@@ -38,7 +37,7 @@ public class Player implements Serializable {
     private User user;
 
     @OneToMany(mappedBy = "player", cascade = CascadeType.ALL)
-    private List<PlayerWord> playerWords = new ArrayList<PlayerWord>();
+    private Set<PlayerWord> playerWords = new HashSet<PlayerWord>();
 
     @ManyToOne
     private Word targetWord;
@@ -69,14 +68,14 @@ public class Player implements Serializable {
         if (thisEffectiveClass != oEffectiveClass) return false;
         Player that = (Player) o;
         return Objects.equals(getId(), that.getId()) &&
-               Objects.equals(getToken(), that.getToken()) &&
-               Objects.equals(getName(), that.getName()) &&
-               Objects.equals(getPoints(), that.getPoints()) &&
-               Objects.equals(getUser(), that.getUser()) &&
-               Objects.equals(getWords(), that.getWords()) &&
-               Objects.equals(getTargetWord(), that.getTargetWord()) &&
-               Objects.equals(getOwnedLobby(), that.getOwnedLobby()) &&
-               Objects.equals(getLobby(), that.getLobby());
+                Objects.equals(getToken(), that.getToken()) &&
+                Objects.equals(getName(), that.getName()) &&
+                Objects.equals(getPoints(), that.getPoints()) &&
+                Objects.equals(getUser(), that.getUser()) &&
+                Objects.equals(getWords(), that.getWords()) &&
+                Objects.equals(getTargetWord(), that.getTargetWord()) &&
+                Objects.equals(getOwnedLobby(), that.getOwnedLobby()) &&
+                Objects.equals(getLobby(), that.getLobby());
     }
 
     @Override
@@ -120,11 +119,11 @@ public class Player implements Serializable {
         this.points += points;
     }
 
-    public List<PlayerWord> getPlayerWords() {
+    public Set<PlayerWord> getPlayerWords() {
         return playerWords;
     }
 
-    public void setPlayerWords(List<PlayerWord> playerWords) {
+    public void setPlayerWords(Set<PlayerWord> playerWords) {
         this.playerWords = playerWords;
     }
 
@@ -133,7 +132,7 @@ public class Player implements Serializable {
     }
 
     public void setWords(List<Word> words) {
-        this.playerWords = words.stream().map(word -> new PlayerWord(this, word)).collect(Collectors.toList());
+        this.playerWords = words.stream().map(word -> new PlayerWord(this, word)).collect(Collectors.toSet());
     }
 
     public void addWord(Word word) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
@@ -1,11 +1,14 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
+import org.hibernate.proxy.HibernateProxy;
+
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 /**
  * Internal Player Representation
@@ -55,6 +58,30 @@ public class Player implements Serializable {
         this.token = token;
         this.name = name;
         this.lobby = lobby;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Player that = (Player) o;
+        return Objects.equals(getId(), that.getId()) &&
+               Objects.equals(getToken(), that.getToken()) &&
+               Objects.equals(getName(), that.getName()) &&
+               Objects.equals(getPoints(), that.getPoints()) &&
+               Objects.equals(getUser(), that.getUser()) &&
+               Objects.equals(getWords(), that.getWords()) &&
+               Objects.equals(getTargetWord(), that.getTargetWord()) &&
+               Objects.equals(getOwnedLobby(), that.getOwnedLobby()) &&
+               Objects.equals(getLobby(), that.getLobby());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
 
     public long getId() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
@@ -29,7 +29,7 @@ public class Player implements Serializable {
     private String name;
 
     @Column
-    private long points;
+    private long points = 0;
 
     @OneToOne(mappedBy = "player")
     private User user;
@@ -91,6 +91,14 @@ public class Player implements Serializable {
 
     public void addPoints(long points) {
         this.points += points;
+    }
+
+    public List<PlayerWord> getPlayerWords() {
+        return playerWords;
+    }
+
+    public void setPlayerWords(List<PlayerWord> playerWords) {
+        this.playerWords = playerWords;
     }
 
     public List<Word> getWords() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/PlayerWord.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/PlayerWord.java
@@ -26,7 +26,7 @@ public class PlayerWord implements Serializable {
     private Player player;
 
     @Id
-    @OneToOne(cascade = CascadeType.PERSIST)
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "word")
     private Word word;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/PlayerWord.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/PlayerWord.java
@@ -1,9 +1,12 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
+import org.hibernate.proxy.HibernateProxy;
+
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 /**
  * Internal PlayerWord Representation
@@ -41,6 +44,23 @@ public class PlayerWord implements Serializable {
     public PlayerWord(Player player, Word word) {
         this.player = player;
         this.word = word;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        PlayerWord that = (PlayerWord) o;
+        return Objects.equals(getPlayer(), that.getPlayer()) &&
+               Objects.equals(getWord(), that.getWord());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
 
     public Player getPlayer() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -1,10 +1,12 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import org.hibernate.proxy.HibernateProxy;
 
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.Objects;
 
 
 /**
@@ -57,6 +59,22 @@ public class User implements Serializable {
 
     @Column(nullable = true, updatable = false)
     private LocalDate creationDate;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        User user = (User) o;
+        return getId() != null && Objects.equals(getId(), user.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 
     public Long getId() {
         return id;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
@@ -1,9 +1,12 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
+import org.hibernate.proxy.HibernateProxy;
+
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 
 @Entity
@@ -27,6 +30,23 @@ public class Word implements Serializable {
         name = name.replaceAll("[^A-Za-z0-9]","");
         name = name.toLowerCase();
         this.name = name;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Word that = (Word) o;
+        return Objects.equals(getName(), that.getName()) &&
+               Objects.equals(getCombinations(), that.getCombinations());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
 
     public String getName() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
@@ -40,8 +40,7 @@ public class Word implements Serializable {
         Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
         if (thisEffectiveClass != oEffectiveClass) return false;
         Word that = (Word) o;
-        return Objects.equals(getName(), that.getName()) &&
-               Objects.equals(getCombinations(), that.getCombinations());
+        return Objects.equals(getName(), that.getName());
     }
 
     @Override

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPlayedDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPlayedDTO.java
@@ -4,11 +4,12 @@ import ch.uzh.ifi.hase.soprafs24.rest.dto.PlayerWordDTO;
 import ch.uzh.ifi.hase.soprafs24.entity.Word;
 
 import java.util.List;
+import java.util.Set;
 
 public class PlayerPlayedDTO {
     private long points;
-    private List<PlayerWordDTO> playerWords;
-    private Word targetWord;
+    private Set<PlayerWordDTO> playerWords;
+    private WordDTO targetWord;
 
     public long getPoints() {
         return points;
@@ -18,19 +19,19 @@ public class PlayerPlayedDTO {
         this.points = points;
     }
 
-    public List<PlayerWordDTO> getPlayerWords() {
+    public Set<PlayerWordDTO> getPlayerWords() {
         return playerWords;
     }
 
-    public void setPlayerWords(List<PlayerWordDTO> playerWords) {
+    public void setPlayerWords(Set<PlayerWordDTO> playerWords) {
         this.playerWords = playerWords;
     }
 
-    public Word getTargetWord() {
+    public WordDTO getTargetWord() {
         return targetWord;
     }
 
-    public void setTargetWord(Word targetWord) {
+    public void setTargetWord(WordDTO targetWord) {
         this.targetWord = targetWord;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPlayedDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPlayedDTO.java
@@ -1,0 +1,36 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs24.rest.dto.PlayerWordDTO;
+import ch.uzh.ifi.hase.soprafs24.entity.Word;
+
+import java.util.List;
+
+public class PlayerPlayedDTO {
+    private long points;
+    private List<PlayerWordDTO> playerWords;
+    private Word targetWord;
+
+    public long getPoints() {
+        return points;
+    }
+
+    public void setPoints(long points) {
+        this.points = points;
+    }
+
+    public List<PlayerWordDTO> getPlayerWords() {
+        return playerWords;
+    }
+
+    public void setPlayerWords(List<PlayerWordDTO> playerWords) {
+        this.playerWords = playerWords;
+    }
+
+    public Word getTargetWord() {
+        return targetWord;
+    }
+
+    public void setTargetWord(Word targetWord) {
+        this.targetWord = targetWord;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerWordDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerWordDTO.java
@@ -1,0 +1,27 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Word;
+
+import java.time.LocalDateTime;
+
+public class PlayerWordDTO {
+    private Word word;
+
+    private LocalDateTime timestamp;
+
+    public Word getWord() {
+        return word;
+    }
+
+    public void setWord(Word word) {
+        this.word = word;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerWordDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerWordDTO.java
@@ -5,15 +5,15 @@ import ch.uzh.ifi.hase.soprafs24.entity.Word;
 import java.time.LocalDateTime;
 
 public class PlayerWordDTO {
-    private Word word;
+    private WordDTO word;
 
     private LocalDateTime timestamp;
 
-    public Word getWord() {
+    public WordDTO getWord() {
         return word;
     }
 
-    public void setWord(Word word) {
+    public void setWord(WordDTO word) {
         this.word = word;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/WordDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/WordDTO.java
@@ -1,0 +1,13 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+public class WordDTO {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.rest.mapper;
 
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.Player;
+import ch.uzh.ifi.hase.soprafs24.entity.PlayerWord;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.*;
 import org.mapstruct.*;
@@ -57,6 +58,15 @@ public interface DTOMapper {
     @Mapping(source = "id", target = "playerId")
     @Mapping(source = "lobby", target = "lobby")
     PlayerJoinedDTO convertEntityToPlayerJoinedDTO(Player player);
+
+    @Mapping(source = "word", target = "word")
+    @Mapping(source = "timestamp", target = "timestamp")
+    PlayerWordDTO convertEntityToPlayerWordDTO(PlayerWord playerWord);
+
+    @Mapping(source = "points", target = "points")
+    @Mapping(source = "playerWords", target = "playerWords")
+    @Mapping(source = "targetWord", target = "targetWord")
+    PlayerPlayedDTO convertEntityToPlayerPlayedDTO(Player player);
 
     @Mapping(source = "username", target = "username")
     @Mapping(source = "favourite", target = "favourite")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -1,9 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.rest.mapper;
 
-import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
-import ch.uzh.ifi.hase.soprafs24.entity.Player;
-import ch.uzh.ifi.hase.soprafs24.entity.PlayerWord;
-import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.entity.*;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.*;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
@@ -62,6 +59,9 @@ public interface DTOMapper {
     @Mapping(source = "word", target = "word")
     @Mapping(source = "timestamp", target = "timestamp")
     PlayerWordDTO convertEntityToPlayerWordDTO(PlayerWord playerWord);
+
+    @Mapping(source = "name", target = "name")
+    WordDTO convertEntityToWordDTO(Word word);
 
     @Mapping(source = "points", target = "points")
     @Mapping(source = "playerWords", target = "playerWords")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -48,12 +48,11 @@ public class GameService {
     }
 
     public void play(Player player, List<Word> words) {
-        Player foundPlayer = playerService.findPlayer(player);
-        Lobby lobby = foundPlayer.getLobby();
+        Lobby lobby = player.getLobby();
         Game game = instantiateGame(lobby.getMode());
-        game.makeCombination(foundPlayer, words);
+        game.makeCombination(player, words);
 
-        if (game.winConditionReached(foundPlayer)) {
+        if (game.winConditionReached(player)) {
             return;  // notify that player has won
         }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlayerService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlayerService.java
@@ -26,21 +26,12 @@ public class PlayerService {
         this.playerRepository = playerRepository;
     }
 
-    public Player findPlayer(Player player) {
-        Player foundPlayer = playerRepository.findByToken(player.getToken());
+    public Player findPlayerByToken(String token) {
+        Player foundPlayer = playerRepository.findByToken(token);
         if (foundPlayer != null) return foundPlayer;
 
-        String errorMessage = String.format("Player %s not found.", player.getName());
+        String errorMessage = String.format("Player with token %s not found.", token);
         throw new ResponseStatusException(HttpStatus.NOT_FOUND, errorMessage);
-    }
-
-    public Player checkToken(String token) {
-        Player foundPlayer = playerRepository.findByToken(token);
-        if (foundPlayer == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No player found with this token");
-        }
-        log.debug("found the player for the provided token: {}", foundPlayer);
-        return foundPlayer;
     }
 
     public void removePlayer(Player player) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -288,6 +288,22 @@ public class LobbyControllerTest {
     }
 
     @Test
+    public void play_invalidId_throwsExceptionUnauthorized() throws Exception {
+        // given
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put(String.format("/lobbies/%s/players/321", testLobby.getCode()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("playerToken", testPlayer1.getToken());
+
+        //then
+        mockMvc.perform(putRequest)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     public void removePlayerNotOwner_validInputs_success() throws Exception {
         // given
         given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer2);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -384,7 +384,7 @@ public class LobbyControllerTest {
         testPlayer2.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1, testPlayer2));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer2);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer2);
         Mockito.doNothing().when(playerService).removePlayer(Mockito.any());
 
         // when
@@ -397,7 +397,7 @@ public class LobbyControllerTest {
         mockMvc.perform(deleteRequest)
                 .andExpect(status().isNoContent());
 
-        Mockito.verify(playerService, Mockito.times(1)).checkToken(Mockito.any());
+        Mockito.verify(playerService, Mockito.times(1)).findPlayerByToken(Mockito.any());
         Mockito.verify(playerService, Mockito.times(1)).removePlayer(Mockito.any());
     }
 
@@ -422,7 +422,7 @@ public class LobbyControllerTest {
         testPlayer2.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1, testPlayer2));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
         Mockito.doNothing().when(lobbyService).removeLobby(Mockito.any());
 
         // when
@@ -435,7 +435,7 @@ public class LobbyControllerTest {
         mockMvc.perform(deleteRequest)
                 .andExpect(status().isNoContent());
 
-        Mockito.verify(playerService, Mockito.times(1)).checkToken(Mockito.any());
+        Mockito.verify(playerService, Mockito.times(1)).findPlayerByToken(Mockito.any());
         Mockito.verify(lobbyService, Mockito.times(1)).removeLobby(Mockito.any());
     }
 
@@ -455,7 +455,7 @@ public class LobbyControllerTest {
         testPlayer1.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/5")
@@ -483,7 +483,7 @@ public class LobbyControllerTest {
         testPlayer1.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/4541/players/5")
@@ -512,7 +512,7 @@ public class LobbyControllerTest {
         testPlayer1.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/four23one/players/5")
@@ -526,7 +526,7 @@ public class LobbyControllerTest {
     }
 
     @Test
-    public void removePlayer_invalidId_throwsNotFoundException() throws Exception {
+    public void removePlayer_invalidId_throwsForbiddenException() throws Exception {
         // given
         Lobby testLobby = new Lobby(1234, "testplayer's Lobby");
         testLobby.setPublicAccess(true);
@@ -541,7 +541,7 @@ public class LobbyControllerTest {
         testPlayer1.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/53")
@@ -551,7 +551,7 @@ public class LobbyControllerTest {
 
         //then
         mockMvc.perform(deleteRequest)
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -570,7 +570,7 @@ public class LobbyControllerTest {
         testPlayer1.setLobby(testLobby);
         testLobby.setPlayers(List.of(testPlayer1));
 
-        given(playerService.checkToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
 
         // when
         MockHttpServletRequestBuilder deleteRequest = delete("/lobbies/1234/players/five")

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -293,9 +293,25 @@ public class LobbyControllerTest {
     }
 
     @Test
+    public void startGame_standard_success() throws Exception {
+        // given
+        given(lobbyService.getLobbyByCode(testLobby.getCode())).willReturn(testLobby);
+
+        // when
+        MockHttpServletRequestBuilder postRequest = post(String.format("/lobbies/%s/games", testLobby.getCode()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("playerToken", testPlayer1.getToken());
+
+        //then
+        mockMvc.perform(postRequest)
+                .andExpect(status().isCreated());
+    }
+
+    @Test
     public void play_standard_success() throws Exception {
         // given
-        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
+        given(playerService.findPlayerByToken(testPlayer1.getToken())).willReturn(testPlayer1);
         List<Word> words = new ArrayList<Word>();
         words.add(new Word("water"));
         words.add(new Word("fire"));
@@ -313,8 +329,7 @@ public class LobbyControllerTest {
         mockMvc.perform(putRequest)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.points", is((int) testPlayer1.getPoints())))
-                .andExpect(jsonPath("$.playerWords[0].word.name", is(testPlayer1.getWords().get(0).getName())))
-                .andExpect(jsonPath("$.playerWords[1].word.name", is(testPlayer1.getWords().get(1).getName())))
+                .andExpect(jsonPath("$.playerWords[*].word.name", containsInAnyOrder(testPlayer1.getWords().stream().map(Word::getName).toArray(String[]::new))))
                 .andExpect(jsonPath("$.targetWord", is(testPlayer1.getTargetWord())));
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/entity/PlayerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/entity/PlayerTest.java
@@ -1,0 +1,47 @@
+package ch.uzh.ifi.hase.soprafs24.entity;
+
+import ch.uzh.ifi.hase.soprafs24.constant.GameMode;
+import ch.uzh.ifi.hase.soprafs24.service.CombinationService;
+import ch.uzh.ifi.hase.soprafs24.service.GameService;
+import ch.uzh.ifi.hase.soprafs24.service.PlayerService;
+import ch.uzh.ifi.hase.soprafs24.service.WordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlayerTest {
+    private Player player;
+
+    private final Word water = new Word("water");
+    private final Word earth = new Word("earth");
+    private final Word fire = new Word("fire");
+    private final Word air = new Word("air");
+    private final Word mud = new Word("mud");
+
+    private List<Word> startingWords;
+
+    @BeforeEach
+    public void setup() {
+        player = new Player();
+        startingWords = new ArrayList<>();
+        startingWords.add(water);
+        startingWords.add(earth);
+        startingWords.add(fire);
+        startingWords.add(air);
+    }
+
+    @Test
+    public void setWords_success() {
+        player.setWords(startingWords);
+        assertEquals(startingWords, player.getWords());
+        assertEquals(startingWords.size(), player.getPlayerWords().size());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/game/GameTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/game/GameTest.java
@@ -1,0 +1,61 @@
+package ch.uzh.ifi.hase.soprafs24.game;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Player;
+import ch.uzh.ifi.hase.soprafs24.entity.Word;
+import ch.uzh.ifi.hase.soprafs24.service.CombinationService;
+import ch.uzh.ifi.hase.soprafs24.service.GameService;
+import ch.uzh.ifi.hase.soprafs24.service.PlayerService;
+import ch.uzh.ifi.hase.soprafs24.service.WordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GameTest {
+    private final Word water = new Word("water");
+    private final Word earth = new Word("earth");
+    private final Word fire = new Word("fire");
+    private final Word air = new Word("air");
+    private final Word mud = new Word("mud");
+
+    private Player player1;
+    private Player player2;
+    private List<Player> players;
+
+    @Mock
+    private PlayerService playerService;
+
+    @Mock
+    private CombinationService combinationService;
+
+    @Mock
+    private WordService wordService;
+
+    @InjectMocks
+    private Game game;
+
+    @BeforeEach
+    public void setup() {
+        player1 = new Player();
+        player2 = new Player();
+        players = new ArrayList<>();
+        players.add(player1);
+        players.add(player2);
+
+        MockitoAnnotations.openMocks(this);
+        Mockito.when(wordService.getWord(Mockito.any())).then(AdditionalAnswers.returnsFirstArg());
+        game.setup();
+    }
+
+    @Test
+    public void setupPlayers_success() {
+        game.setupPlayers(players);
+
+        assertEquals(4, player1.getWords().size());
+        assertEquals(4, player2.getWords().size());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/PlayerRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/PlayerRepositoryIntegrationTest.java
@@ -123,6 +123,16 @@ public class PlayerRepositoryIntegrationTest {
     }
 
     @Test
+    public void addWord_sameWordDifferentPlayer_success() {
+        Word water = new Word("water");
+        testPlayer1.addWord(water);
+        testPlayer2.addWord(water);
+
+        assertTrue(testPlayer1.getWords().contains(water));
+        assertTrue(testPlayer2.getWords().contains(water));
+    }
+
+    @Test
     public void findById_success() {
         // when
         Player found = playerRepository.findById(testPlayer1.getId());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/PlayerRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/PlayerRepositoryIntegrationTest.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.entity.Word;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,23 +25,29 @@ public class PlayerRepositoryIntegrationTest {
     private TestEntityManager entityManager;
 
     @Autowired
-    private PlayerRepository playerRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private LobbyRepository lobbyRepository;
 
     @Autowired
-    private UserRepository userRepository;
+    private PlayerWordRepository playerWordRepository;
 
-    private Player testPlayer1;
+    @Autowired
+    private WordRepository wordRepository;
 
-    private Player testPlayer2;
-
-    private Lobby testLobby;
+    @Autowired
+    private PlayerRepository playerRepository;
 
     private User testUser1;
 
     private User testUser2;
+
+    private Lobby testLobby;
+
+    private Player testPlayer1;
+
+    private Player testPlayer2;
 
     @BeforeEach
     public void setup() {
@@ -88,9 +95,31 @@ public class PlayerRepositoryIntegrationTest {
 
     @AfterEach
     public void cleanup() {
+        userRepository.deleteAll();
         lobbyRepository.deleteAll();
         playerRepository.deleteAll();
-        userRepository.deleteAll();
+        wordRepository.deleteAll();
+        playerWordRepository.deleteAll();
+    }
+
+    @Test
+    public void addSingleWord_success() {
+        Word water = new Word("water");
+        testPlayer1.addWord(water);
+
+        assertEquals(1, testPlayer1.getPlayerWords().size());
+        assertTrue(testPlayer1.getWords().contains(water));
+    }
+
+    @Test
+    public void addWord_sameWordTwice_success() {
+        Word water = new Word("water");
+        testPlayer1.addWord(water);
+        testPlayer1.addWord(water);
+        testPlayer1.addWord(new Word("water"));
+
+        assertEquals(1, testPlayer1.getPlayerWords().size());
+        assertTrue(testPlayer1.getWords().contains(water));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
@@ -7,10 +7,7 @@ import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.Word;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -47,6 +44,7 @@ public class GameServiceTest {
         startingWords.add(air);
 
         MockitoAnnotations.openMocks(this);
+        Mockito.when(wordService.getWord(Mockito.any())).then(AdditionalAnswers.returnsFirstArg());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
@@ -86,7 +86,6 @@ public class GameServiceTest {
 
         Combination testCombination = new Combination(water, earth, mud);
 
-        Mockito.when(playerService.findPlayer(testPlayer)).thenReturn(testPlayer);
         Mockito.when(combinationService.getCombination(water, earth)).thenReturn(testCombination);
 
         assertEquals(startingWords, testPlayer.getWords());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
@@ -51,34 +51,42 @@ public class GameServiceTest {
 
     @Test
     public void createNewGame_success() {
-        Player testPlayer = new Player();
+        Player testPlayer1 = new Player();
+        Player testPlayer2 = new Player();
+
         List<Player> testPlayers = new ArrayList<Player>();
-        testPlayers.add(testPlayer);
+        testPlayers.add(testPlayer1);
+        testPlayers.add(testPlayer2);
 
         Lobby testLobby = new Lobby();
         testLobby.setMode(GameMode.STANDARD);
         testLobby.setPlayers(testPlayers);
 
-        assertEquals(0, testPlayer.getWords().size());
+        assertEquals(0, testPlayer1.getWords().size());
+        assertEquals(0, testPlayer2.getWords().size());
 
         gameService.createNewGame(testLobby);
 
-        assertEquals(4, testPlayer.getWords().size());
+        assertEquals(4, testPlayer1.getWords().size());
+        assertEquals(4, testPlayer2.getWords().size());
     }
 
     @Test
     public void play_success() {
-        Player testPlayer = new Player();
+        Player testPlayer1 = new Player();
+        Player testPlayer2 = new Player();
 
-        testPlayer.setWords(startingWords);
+        testPlayer1.setWords(startingWords);
+        testPlayer2.setWords(startingWords);
 
         List<Player> testPlayers = new ArrayList<Player>();
-        testPlayers.add(testPlayer);
+        testPlayers.add(testPlayer1);
+        testPlayers.add(testPlayer2);
 
         Lobby testLobby = new Lobby();
         testLobby.setMode(GameMode.STANDARD);
 
-        testPlayer.setLobby(testLobby);
+        testPlayer1.setLobby(testLobby);
 
         List<Word> playingWords = new ArrayList<>();
         playingWords.add(water);
@@ -88,10 +96,10 @@ public class GameServiceTest {
 
         Mockito.when(combinationService.getCombination(water, earth)).thenReturn(testCombination);
 
-        assertEquals(startingWords, testPlayer.getWords());
+        assertEquals(startingWords, testPlayer1.getWords());
 
-        gameService.play(testPlayer, playingWords);
+        gameService.play(testPlayer1, playingWords);
 
-        assertEquals(mud, testPlayer.getWords().get(4));
+        assertEquals(mud, testPlayer1.getWords().get(4));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceIntegrationTest.java
@@ -46,22 +46,22 @@ public class PlayerServiceIntegrationTest {
     }
 
     @Test
-    public void checkToken_validInput_success() {
+    public void findPlayerByToken_validInput_success() {
         Player testPlayer = new Player("234", "test", null);
         playerRepository.save(testPlayer);
 
-        Player checkedPlayer = playerService.checkToken(testPlayer.getToken());
+        Player checkedPlayer = playerService.findPlayerByToken(testPlayer.getToken());
         assertEquals(testPlayer.getToken(), checkedPlayer.getToken());
         assertEquals(testPlayer.getPoints(), checkedPlayer.getPoints());
         assertEquals(testPlayer.getName(), checkedPlayer.getName());
     }
 
     @Test
-    public void checkToken_invalidToken_throwsNotFoundException() {
+    public void findPlayerByToken_invalidToken_throwsNotFoundException() {
         Player testPlayer = new Player("345", "tester", null);
         playerRepository.save(testPlayer);
 
-        assertThrows(ResponseStatusException.class, () -> playerService.checkToken(testPlayer.getToken()+"23"));
+        assertThrows(ResponseStatusException.class, () -> playerService.findPlayerByToken(testPlayer.getToken()+"23"));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlayerServiceTest.java
@@ -65,20 +65,20 @@ public class PlayerServiceTest {
     }
 
     @Test
-    public void checkToken_validInput_success() {
+    public void findPlayerByToken_validInput_success() {
         Mockito.when(playerRepository.findByToken(Mockito.anyString())).thenReturn(testPlayer1);
 
-        Player checkedPlayer = playerService.checkToken(testPlayer1.getToken());
+        Player checkedPlayer = playerService.findPlayerByToken(testPlayer1.getToken());
         assertEquals(testPlayer1.getId(), checkedPlayer.getId());
         assertEquals(testPlayer1.getName(), checkedPlayer.getName());
         assertEquals(testPlayer1.getPoints(), checkedPlayer.getPoints());
     }
 
     @Test
-    public void checkToken_invalidToken_throwsNotFoundException() {
+    public void findPlayerByToken_invalidToken_throwsNotFoundException() {
         Mockito.when(playerRepository.findByToken(Mockito.anyString())).thenReturn(null);
 
-        assertThrows(ResponseStatusException.class, () -> playerService.checkToken(Mockito.anyString()));
+        assertThrows(ResponseStatusException.class, () -> playerService.findPlayerByToken(Mockito.anyString()));
     }
 
     @Test


### PR DESCRIPTION
- Changes to LobbyController
  - extracted player and lobby authentication
  - added startGame and play endpoints
- Changes to various entities
  - merged Timon's [equals](https://github.com/sopra-fs24-group-41/sopra-fs24-group-41-server/tree/equals) branch to add equality checks and hashs to entities
  - fixed PlayerWord to allow same word belonging to multiple players
- Changes to DTOs
  - added some useful DTOs
- Changes to PlayerService
  - we used to have two methods, findPlayer and checkToken. They basically did the same thing. I combined them into findPlayerByToken, which is now used everywhere 
- Tests
  - added various tests. Notably refactored LobbyControllerTest and extracted creation of test objects into the setup method.  