### PR TITLE
Profile img persist (adjustments for client)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -67,8 +67,6 @@ public class UserController {
         userService.authUser(id, token);
         User Update = DTOMapper.INSTANCE.convertUserPutDTOtoEntity(userPutDTO);
         User updatedUser = userService.editUser(token, Update);
-        System.out.println(updatedUser.getUsername());
-        System.out.println(updatedUser.getProfilePicture());
         return DTOMapper.INSTANCE.convertEntityToUserGetDTO(updatedUser);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -67,6 +67,8 @@ public class UserController {
         userService.authUser(id, token);
         User Update = DTOMapper.INSTANCE.convertUserPutDTOtoEntity(userPutDTO);
         User updatedUser = userService.editUser(token, Update);
+        System.out.println(updatedUser.getUsername());
+        System.out.println(updatedUser.getProfilePicture());
         return DTOMapper.INSTANCE.convertEntityToUserGetDTO(updatedUser);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController {
     }
 
     @PutMapping("/users/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public UserGetDTO editUser(@PathVariable("id") Long id,
                          @RequestBody UserPutDTO userPutDTO,

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPutDTO.java
@@ -4,6 +4,8 @@ public class UserPutDTO {
     private String username;
     private String favourite;
 
+    private String profilePicture;
+
     public String getUsername() {
         return username;
     }
@@ -19,4 +21,10 @@ public class UserPutDTO {
     public void setFavourite(String favourite) {
         this.favourite = favourite;
     }
+
+    public String getProfilePicture() { return profilePicture; }
+
+    public void setProfilePicture(String profilePicture){this.profilePicture = profilePicture;}
+
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -70,6 +70,7 @@ public interface DTOMapper {
 
     @Mapping(source = "username", target = "username")
     @Mapping(source = "favourite", target = "favourite")
+    @Mapping(source = "profilePicture", target = "profilePicture")
     User convertUserPutDTOtoEntity(UserPutDTO userPutDTO);
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -131,46 +131,43 @@ public class UserService {
 
     public void usernameValidation(String username){
         if(username.isEmpty()){
-            throw new ResponseStatusException(HttpStatus.PRECONDITION_FAILED, "Username may not be left empty");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not be left empty");
         }
 
         if(username.contains(" ")){
-            throw new ResponseStatusException(HttpStatus.PRECONDITION_FAILED, "Username may not contain blank spaces");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not contain blank spaces");
         }
     }
 
     public void favouriteValidation(String favourite){
         if(favourite.contains(" ")){
-            throw new ResponseStatusException(HttpStatus.PRECONDITION_FAILED, "Favourite word may not contain blank spaces");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Favourite word may not contain blank spaces");
         }
     }
 
     public User editUser(String token, User updatedUser){
         User foundUser = userRepository.findByToken(token);
 
+        //Input validation
+        usernameValidation(updatedUser.getUsername());
+        favouriteValidation(updatedUser.getFavourite());
+
         User conflictUser = userRepository.findByUsername(updatedUser.getUsername());
         if(conflictUser != null && conflictUser!=foundUser){
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already taken, please choose a different one");
         }
 
-        usernameValidation(updatedUser.getUsername());
-        favouriteValidation(updatedUser.getFavourite());
-
-        if(updatedUser.getProfilePicture()==null){
-            updatedUser.setProfilePicture("");
-        }
-
+        //Update data
         if(!Objects.equals(foundUser.getUsername(), updatedUser.getUsername())){
-                foundUser.setUsername(updatedUser.getUsername());}
+            foundUser.setUsername(updatedUser.getUsername());}
 
         if(!Objects.equals(foundUser.getFavourite(), updatedUser.getFavourite())){
-                foundUser.setFavourite(updatedUser.getFavourite());}
-
+            foundUser.setFavourite(updatedUser.getFavourite());}
         if(updatedUser.getFavourite().isEmpty()){
             foundUser.setFavourite("Zaddy");
         }
 
-        if(!Objects.equals(foundUser.getProfilePicture(), updatedUser.getProfilePicture())){
+        if(updatedUser.getProfilePicture() != null && !Objects.equals(foundUser.getProfilePicture(), updatedUser.getProfilePicture())){
             foundUser.setProfilePicture(updatedUser.getProfilePicture());
         }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -130,7 +130,7 @@ public class UserService {
     }
 
     public void usernameValidation(String username){
-        if(username.isEmpty()){
+        if(username == null || username.isEmpty()){
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not be left empty");
         }
 
@@ -140,6 +140,10 @@ public class UserService {
     }
 
     public void favouriteValidation(String favourite){
+        if(favourite == null){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not be left empty");
+        }
+
         if(favourite.contains(" ")){
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Favourite word may not contain blank spaces");
         }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -130,24 +130,21 @@ public class UserService {
     }
 
     public void usernameValidation(String username){
-        if(username == null || username.isEmpty()){
+        if(username != null && username.isEmpty()){
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not be left empty");
         }
 
-        if(username.contains(" ")){
+        if(username != null && username.contains(" ")){
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not contain blank spaces");
         }
     }
 
     public void favouriteValidation(String favourite){
-        if(favourite == null){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username may not be left empty");
-        }
-
-        if(favourite.contains(" ")){
+        if(favourite != null && favourite.contains(" ")){
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Favourite word may not contain blank spaces");
         }
     }
+
 
     public User editUser(String token, User updatedUser){
         User foundUser = userRepository.findByToken(token);
@@ -162,19 +159,18 @@ public class UserService {
         }
 
         //Update data
-        if(!Objects.equals(foundUser.getUsername(), updatedUser.getUsername())){
+        if(updatedUser.getUsername()!=null && !Objects.equals(foundUser.getUsername(), updatedUser.getUsername())){
             foundUser.setUsername(updatedUser.getUsername());}
 
-        if(!Objects.equals(foundUser.getFavourite(), updatedUser.getFavourite())){
+        if(updatedUser.getFavourite()!=null && !Objects.equals(foundUser.getFavourite(), updatedUser.getFavourite())){
             foundUser.setFavourite(updatedUser.getFavourite());}
-        if(updatedUser.getFavourite().isEmpty()){
+        if(updatedUser.getFavourite()!=null && updatedUser.getFavourite().isEmpty()){
             foundUser.setFavourite("Zaddy");
         }
 
-        if(updatedUser.getProfilePicture() != null && !Objects.equals(foundUser.getProfilePicture(), updatedUser.getProfilePicture())){
+        if(updatedUser.getProfilePicture()!=null && !Objects.equals(foundUser.getProfilePicture(), updatedUser.getProfilePicture())){
             foundUser.setProfilePicture(updatedUser.getProfilePicture());
         }
-
         return foundUser;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -156,6 +156,10 @@ public class UserService {
         usernameValidation(updatedUser.getUsername());
         favouriteValidation(updatedUser.getFavourite());
 
+        if(updatedUser.getProfilePicture()==null){
+            updatedUser.setProfilePicture("");
+        }
+
         if(!Objects.equals(foundUser.getUsername(), updatedUser.getUsername())){
                 foundUser.setUsername(updatedUser.getUsername());}
 
@@ -165,6 +169,11 @@ public class UserService {
         if(updatedUser.getFavourite().isEmpty()){
             foundUser.setFavourite("Zaddy");
         }
+
+        if(!Objects.equals(foundUser.getProfilePicture(), updatedUser.getProfilePicture())){
+            foundUser.setProfilePicture(updatedUser.getProfilePicture());
+        }
+
         return foundUser;
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,6 +34,8 @@ public class UserServiceTest {
         testUser.setPassword("testPassword");
         testUser.setUsername("testUsername");
         testUser.setToken("1234");
+        testUser.setFavourite("Zaddy");
+        testUser.setProfilePicture("BlueFrog");
 
         // when -> any object is being save in the userRepository -> return the dummy
         // testUser
@@ -164,5 +167,151 @@ public class UserServiceTest {
         Mockito.when(userRepository.findByToken(Mockito.any())).thenReturn(null);
 
         assertThrows(ResponseStatusException.class, () -> userService.checkToken(Mockito.any()));
+    }
+
+    @Test
+    public void update_success() {
+        // Mocking repository behavior
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        // Creating an updated user
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("Daddy");
+        updatedUser.setUsername("Jason");
+
+        // Invoking the method under test
+        User checkUser = userService.editUser("1234", updatedUser);
+
+        // Assertions
+        assertEquals(checkUser.getFavourite(), updatedUser.getFavourite());
+        assertEquals(checkUser.getUsername(), updatedUser.getUsername());
+        assertEquals(checkUser.getProfilePicture(), updatedUser.getProfilePicture());
+    }
+
+    @Test
+    public void update_fail_username_with_spaces() {
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("Daddy");
+        updatedUser.setUsername("Jas on");
+
+        // Catching the ResponseStatusException
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> userService.editUser("1234", updatedUser));
+
+        // Verifying the status code
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+    }
+
+    @Test
+    public void update_fail_username_empty() {
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("Daddy");
+        updatedUser.setUsername("");
+
+        // Catching the ResponseStatusException
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> userService.editUser("1234", updatedUser));
+
+        // Verifying the status code
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+    }
+
+    @Test
+    public void update_fail_favourite_with_spaces() {
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("Da ddy");
+        updatedUser.setUsername("Jason");
+
+        // Catching the ResponseStatusException
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> userService.editUser("1234", updatedUser));
+
+        // Verifying the status code
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+    }
+
+    @Test
+    public void update_fail_conflict() {
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        User conflictUser = new User();
+        conflictUser.setUsername("Jason");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(conflictUser);
+
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("Dadddy");
+        updatedUser.setUsername("Jason");
+
+        // Catching the ResponseStatusException
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> userService.editUser("1234", updatedUser));
+
+        // Verifying the status code
+        assertEquals(HttpStatus.CONFLICT, exception.getStatus());
+    }
+
+    @Test
+    public void update_success_empty_favourite_to_zaddy() {
+        // Mocking repository behavior
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        // Creating an updated user
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("");
+        updatedUser.setUsername("Jason");
+
+        // Invoking the method under test
+        User checkUser = userService.editUser("1234", updatedUser);
+
+        // Assertions
+        assertEquals(checkUser.getFavourite(), "Zaddy");
+
+    }
+
+    @Test
+    public void update_success_unchanged_username() {
+        // Mocking repository behavior
+        User foundUser = new User();
+        foundUser.setUsername("Peter");
+        Mockito.when(userRepository.findByToken("1234")).thenReturn(foundUser);
+        Mockito.when(userRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        // Creating an updated user
+        User updatedUser = new User();
+        updatedUser.setProfilePicture("PinkBunny");
+        updatedUser.setFavourite("Daddy");
+        updatedUser.setUsername("Peter");
+
+        // Invoking the method under test
+        User checkUser = userService.editUser("1234", updatedUser);
+
+        // Assertions
+        assertEquals(checkUser.getFavourite(), updatedUser.getFavourite());
+        assertEquals(checkUser.getUsername(), updatedUser.getUsername());
+        assertEquals(checkUser.getProfilePicture(), updatedUser.getProfilePicture());
     }
 }


### PR DESCRIPTION
I added profile pictures to the UserPutDTO such that the Client is now able to meaningfully use the already present 'profilePicture' attribute that stores a string.
We store the name of the Image file of the Client on the Server and when the Client retrieves information from the Server, it will then just render the corresponding image. For M3, I suggest to leave it with the image names and for M4, we can change it up with encodings.

At the time of writing (20.04.2024, 1pm) the branch with the same name on the Client side is not fully complete, as I still plan to add more profile pictures but I don't think I need any more adjustment on the Server side.

Please check out the code and point out other stuff I might need to consider, I'm not too good in Java after all. 

