### PR TITLE
Anonymous players

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,7 @@ jobs:
         run: ./gradlew build
         env:
           SPRING_PROFILES_ACTIVE: postgres-cloud
+          SPRING_JPA_HIBERNATE_DDL_AUTO: create
           DATABASE_URL: ${{ secrets.TESTING_DATABASE_URL }}
           DATABASE_USERNAME: ${{ secrets.TESTING_DATABASE_USERNAME }}
           DATABASE_PASSWORD: ${{ secrets.TESTING_DATABASE_PASSWORD }}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -85,8 +85,10 @@ public class LobbyController {
         if (playerPostDTO.getPlayerName() == null || playerPostDTO.getPlayerName().isEmpty()) {
             playerPostDTO.setPlayerName("Randy");
         }
+        // set maximum allowed length of playerName
+        playerPostDTO.setPlayerName(playerPostDTO.getPlayerName().substring(0, Math.min(playerPostDTO.getPlayerName().length(), 20)));
 
-        Player player = null;
+        Player player;
         if (userToken != null && !userToken.isEmpty()) {
             User user = userService.checkToken(userToken);
             if (user.getPlayer() != null) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -86,20 +86,19 @@ public class LobbyController {
             playerPostDTO.setPlayerName("Randy");
         }
 
+        Player player = null;
         if (userToken != null && !userToken.isEmpty()) {
             User user = userService.checkToken(userToken);
             if (user.getPlayer() != null) {
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "Your user already has a lobby associated, leave it before joining a new one.");
             }
-            Player player = lobbyService.joinLobbyFromUser(user, lobbyCodeLong);
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + code, DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(player.getLobby()));
-            return DTOMapper.INSTANCE.convertEntityToPlayerJoinedDTO(player);
+            player = lobbyService.joinLobbyFromUser(user, lobbyCodeLong);
         }
         else {
-            Player player = lobbyService.joinLobbyAnonymous(playerPostDTO.getPlayerName(), lobbyCodeLong);
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + code, DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(player.getLobby()));
-            return DTOMapper.INSTANCE.convertEntityToPlayerJoinedDTO(player);
+            player = lobbyService.joinLobbyAnonymous(playerPostDTO.getPlayerName(), lobbyCodeLong);
         }
+        messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + code, DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(player.getLobby()));
+        return DTOMapper.INSTANCE.convertEntityToPlayerJoinedDTO(player);
     }
 
     @GetMapping("/lobbies/{code}/players")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -85,8 +85,6 @@ public class LobbyController {
         if (playerPostDTO.getPlayerName() == null || playerPostDTO.getPlayerName().isEmpty()) {
             playerPostDTO.setPlayerName("Randy");
         }
-        // set maximum allowed length of playerName
-        playerPostDTO.setPlayerName(playerPostDTO.getPlayerName().substring(0, Math.min(playerPostDTO.getPlayerName().length(), 20)));
 
         Player player;
         if (userToken != null && !userToken.isEmpty()) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -141,4 +141,8 @@ public class Lobby implements Serializable {
     public void setPlayers(List<Player> players) {
         this.players = players;
     }
+
+    public void addPlayer(Player player) {
+        this.players.add(player);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepository.java
@@ -15,7 +15,7 @@ public interface LobbyRepository extends JpaRepository<Lobby, Long> {
 
     List<Lobby> findAllByPublicAccess(boolean publicAccess);
 
-    Lobby findByOwner_Id(long owner_id);
+    Lobby findByOwner_Id(long ownerId);
 
     List<Lobby> findAllByMode(GameMode mode);
 
@@ -23,5 +23,5 @@ public interface LobbyRepository extends JpaRepository<Lobby, Long> {
 
     Lobby findByPlayersIsContaining(Player player);
 
-    Boolean existsByCode(long code);
+    boolean existsByCode(long code);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyPostDTO.java
@@ -2,13 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.rest.dto;
 
 public class LobbyPostDTO {
 
-    private String name;
-
     private Boolean publicAccess;
-
-    private String word1;
-
-    private String word2;
 
     public Boolean getPublicAccess() {
         return publicAccess;
@@ -16,29 +10,5 @@ public class LobbyPostDTO {
 
     public void setPublicAccess(Boolean publicAccess) {
         this.publicAccess = publicAccess;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getWord1() {
-        return word1;
-    }
-
-    public void setWord1(String word1) {
-        this.word1 = word1;
-    }
-
-    public String getWord2() {
-        return word2;
-    }
-
-    public void setWord2(String word2) {
-        this.word2 = word2;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPostDTO.java
@@ -9,6 +9,6 @@ public class PlayerPostDTO {
     }
 
     public void setPlayerName(String playerName) {
-        this.playerName = playerName;
+        this.playerName = playerName.substring(0, Math.min(playerName.length(), 20));
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlayerPostDTO.java
@@ -1,0 +1,14 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+public class PlayerPostDTO {
+
+    private String playerName;
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -74,7 +74,7 @@ public class LobbyService {
 
         Player player = new Player(UUID.randomUUID().toString(), user.getUsername(), foundLobby);
         player.setUser(user);
-        foundLobby.getPlayers().add(player);
+        foundLobby.addPlayer(player);
         user.setPlayer(player);
 
         log.debug("user joined -> updated lobby {}", foundLobby);
@@ -90,7 +90,7 @@ public class LobbyService {
         }
 
         Player player = new Player(UUID.randomUUID().toString(), playerName, foundLobby);
-        foundLobby.getPlayers().add(player);
+        foundLobby.addPlayer(player);
         log.debug("updated lobby {}", foundLobby);
         log.debug("created new anonymous player from player name {}", player);
         return player;
@@ -134,7 +134,7 @@ public class LobbyService {
 
     private long generateLobbyCode() {
         long code = ThreadLocalRandom.current().nextLong(1000, 10000);
-        while (Boolean.TRUE.equals(lobbyRepository.existsByCode(code))) {
+        while (lobbyRepository.existsByCode(code)) {
             code = ThreadLocalRandom.current().nextLong(1000, 10000);
         }
         return code;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -2,10 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.controller;
 
 import ch.uzh.ifi.hase.soprafs24.constant.GameMode;
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
-import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
-import ch.uzh.ifi.hase.soprafs24.entity.Player;
-import ch.uzh.ifi.hase.soprafs24.entity.User;
-import ch.uzh.ifi.hase.soprafs24.entity.Word;
+import ch.uzh.ifi.hase.soprafs24.entity.*;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPostDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPutDTO;
 import ch.uzh.ifi.hase.soprafs24.service.*;
@@ -144,6 +141,22 @@ class LobbyControllerTest {
                 .andExpect(jsonPath("$[0].owner.user.status", is(testLobby.getOwner().getUser().getStatus().toString())))
                 .andExpect(jsonPath("$[0].owner.user.profilePicture", is(testLobby.getOwner().getUser().getProfilePicture())))
                 .andExpect(jsonPath("$[0].players", hasSize(2)));
+    }
+
+    @Test
+    void givenNoLobbies_validCode_thenReturnEmptyList() throws Exception {
+        // given
+        given(lobbyService.getPublicLobbies()).willReturn(new ArrayList<>());
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/lobbies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
     }
 
     @Test
@@ -408,6 +421,50 @@ class LobbyControllerTest {
     }
 
     @Test
+    void getPlayers_validInputs_thenReturnsPlayers() throws Exception {
+        // given
+        given(lobbyService.getLobbyByCode(Mockito.anyLong())).willReturn(testLobby);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get(String.format("/lobbies/%s/players", testLobby.getCode()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].id", containsInAnyOrder(testLobby.getPlayers().stream().map(Player::getId).map(Long::intValue).toArray())))
+                .andExpect(jsonPath("$[*].name", containsInAnyOrder(testLobby.getPlayers().stream().map(Player::getName).toArray())))
+                .andExpect(jsonPath("$[*].points", containsInAnyOrder(testLobby.getPlayers().stream().map(Player::getPoints).map(Long::intValue).toArray())));
+//                .andExpect(jsonPath("$[*].user.username", containsInAnyOrder(testLobby.getPlayers().stream().map(Player::getUser).map(User::getUsername).toArray())))
+//                .andExpect(jsonPath("$[*].user.status", containsInAnyOrder(testLobby.getPlayers().stream().map(Player::getUser).map(User::getStatus).map(UserStatus::toString).toArray())))
+//                .andExpect(jsonPath("$[*].user.profilePicture", containsInAnyOrder(testLobby.getPlayers().stream().map(Player::getUser).map(User::getProfilePicture).toArray())));
+    }
+
+    @Test
+    void getPlayer_validInputs_thenReturnsPlayer() throws Exception {
+        // given
+        given(playerService.findPlayerByToken(Mockito.any())).willReturn(testPlayer1);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get(String.format("/lobbies/%s/players/%s", testLobby.getCode(), testPlayer1.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("playerToken", testPlayer1.getToken());
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is((int)testPlayer1.getId())))
+                .andExpect(jsonPath("$.name", is(testPlayer1.getName())))
+                .andExpect(jsonPath("$.points", is((int)testPlayer1.getPoints())));
+//                .andExpect(jsonPath("$.user.username", is(testPlayer1.getUser().getUsername())))
+//                .andExpect(jsonPath("$.user.status", is(testPlayer1.getUser().getStatus().toString())))
+//                .andExpect(jsonPath("$.user.profilePicture", is(testPlayer1.getUser().getProfilePicture())));
+    }
+
+    @Test
     void startGame_standard_success() throws Exception {
         // given
         given(lobbyService.getLobbyByCode(testLobby.getCode())).willReturn(testLobby);
@@ -463,6 +520,24 @@ class LobbyControllerTest {
         //then
         mockMvc.perform(putRequest)
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getCombination_validInputs_thenReturnsCombination() throws Exception {
+        // given
+        given(combinationService.findCombination(Mockito.any(), Mockito.any()))
+                .willReturn(new Combination(new Word("water"), new Word("fire"), new Word("steam")));
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get(String.format("/combinations/%s/%s", "water", "fire"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("method", "find");
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("steam")));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepositoryIntegrationTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-public class LobbyRepositoryIntegrationTest {
+class LobbyRepositoryIntegrationTest {
 
     @Autowired
     private TestEntityManager entityManager;
@@ -87,14 +87,14 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         lobbyRepository.deleteAll();
         playerRepository.deleteAll();
         userRepository.deleteAll();
     }
 
     @Test
-    public void findByCode_success() {
+    void findByCode_success() {
         // when
         Lobby found = lobbyRepository.findByCode(testLobby.getCode());
 
@@ -109,7 +109,7 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @Test
-    public void findAllByPublicAccess_success() {
+    void findAllByPublicAccess_success() {
         // given
         Lobby lobby2 = new Lobby(4521, "lobby2");
         lobby2.setPublicAccess(true);
@@ -124,7 +124,7 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @Test
-    public void findByOwner_Id_success() {
+    void findByOwner_Id_success() {
         // when
         Lobby found = lobbyRepository.findByOwner_Id(testLobby.getOwner().getId());
 
@@ -139,7 +139,7 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @Test
-    public void findAllByMode_success() {
+    void findAllByMode_success() {
         // when
         List<Lobby> found = lobbyRepository.findAllByMode(testLobby.getMode());
         Lobby[] lobbyList = new Lobby[]{testLobby};
@@ -149,7 +149,7 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @Test
-    public void findAllByStatus_success() {
+    void findAllByStatus_success() {
         // when
         List<Lobby> found = lobbyRepository.findAllByStatus(testLobby.getStatus());
         Lobby[] lobbyList = new Lobby[]{testLobby};
@@ -159,7 +159,7 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @Test
-    public void findByPlayersIsContaining_success() {
+    void findByPlayersIsContaining_success() {
         // when
         Lobby found = lobbyRepository.findByPlayersIsContaining(testPlayer2);
 
@@ -174,12 +174,12 @@ public class LobbyRepositoryIntegrationTest {
     }
 
     @Test
-    public void existsByCode_success() {
+    void existsByCode_success() {
         assertTrue(lobbyRepository.existsByCode(testLobby.getCode()));
     }
 
     @Test
-    public void cascadePlayers_success() {
+    void cascadePlayers_success() {
         // when
         List<Player> found = playerRepository.findAllByLobby_Code(testLobby.getCode());
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -218,7 +218,7 @@ class LobbyServiceTest {
     void removeLobby_success() {
         // given
         Player testPlayer2 = new Player("234", "testPlayer2", testLobby);
-        testLobby.getPlayers().add(testPlayer2);
+        testLobby.addPlayer(testPlayer2);
 
         Mockito.doNothing().when(lobbyRepository).delete(Mockito.any());
         Mockito.doNothing().when(playerService).removePlayer(Mockito.any());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class LobbyServiceTest {
+class LobbyServiceTest {
 
     @Mock
     private LobbyRepository lobbyRepository;
@@ -120,6 +120,13 @@ public class LobbyServiceTest {
         assertEquals(testLobby.getOwner(), createdPlayer.getLobby().getOwner());
         assertArrayEquals(testLobby.getPlayers().toArray(), createdPlayer.getLobby().getPlayers().toArray());
     }
+
+    @Test
+    void createLobbyFromUser_publicAccessFalse_success() {
+        Player createdPlayer = lobbyService.createLobbyFromUser(testUser, false);
+        assertFalse(createdPlayer.getLobby().getPublicAccess());
+    }
+
     @Test
     void updateLobby_validInput_success() {
         LobbyPutDTO lobbyPutDTO = new LobbyPutDTO();
@@ -134,6 +141,15 @@ public class LobbyServiceTest {
         assertEquals(lobbyPutDTO.getPublicAccess(), testLobby.getPublicAccess());
         assertEquals(lobbyPutDTO.getMode(), testLobby.getMode());
         assertEquals(lobbyPutDTO.getName(), testLobby.getName());
+    }
+
+    @Test
+    void updateLobby_noUpdates_success() {
+        LobbyPutDTO lobbyPutDTO = new LobbyPutDTO();
+        Map<String, Boolean> updates = lobbyService.updateLobby(testLobby, lobbyPutDTO);
+        assertFalse(updates.get("publicAccess"));
+        assertFalse(updates.get("mode"));
+        assertFalse(updates.get("name"));
     }
 
     @Test
@@ -162,8 +178,40 @@ public class LobbyServiceTest {
     void joinLobbyByUser_lobbyNotPregame_throwsForbiddenError() {
         testLobby.setStatus(LobbyStatus.INGAME);
         Mockito.when(lobbyRepository.findByCode(Mockito.anyLong())).thenReturn(testLobby);
+        long lobbyCode = testLobby.getCode();
 
-        assertThrows(ResponseStatusException.class, () -> lobbyService.joinLobbyFromUser(testUser, testLobby.getCode()));
+        assertThrows(ResponseStatusException.class, () -> lobbyService.joinLobbyFromUser(testUser, lobbyCode));
+    }
+
+    @Test
+    void joinLobbyAnonymous_validInput_success() {
+        Mockito.when(lobbyRepository.findByCode(Mockito.anyLong())).thenReturn(testLobby);
+        Player createdPlayer = lobbyService.joinLobbyAnonymous("testPlayer2", testLobby.getCode());
+
+        // then
+        assertEquals(testLobby.getCode(), createdPlayer.getLobby().getCode());
+        assertEquals(testLobby.getName(), createdPlayer.getLobby().getName());
+        assertEquals(testLobby.getPublicAccess(), createdPlayer.getLobby().getPublicAccess());
+        assertEquals(testLobby.getStatus(), createdPlayer.getLobby().getStatus());
+        assertEquals(testLobby.getMode(), createdPlayer.getLobby().getMode());
+        assertEquals(testLobby.getOwner(), createdPlayer.getLobby().getOwner());
+        assertEquals(testLobby.getPlayers(), createdPlayer.getLobby().getPlayers());
+    }
+
+    @Test
+    void joinLobbyAnonymous_invalidCode_throwsNotFoundError() {
+        Mockito.when(lobbyRepository.findByCode(Mockito.anyLong())).thenReturn(null);
+
+        assertThrows(ResponseStatusException.class, () -> lobbyService.joinLobbyAnonymous("testPlayer2", 232));
+    }
+
+    @Test
+    void joinLobbyAnonymous_lobbyNotPregame_throwsForbiddenError() {
+        testLobby.setStatus(LobbyStatus.INGAME);
+        Mockito.when(lobbyRepository.findByCode(Mockito.anyLong())).thenReturn(testLobby);
+        long lobbyCode = testLobby.getCode();
+
+        assertThrows(ResponseStatusException.class, () -> lobbyService.joinLobbyAnonymous("testPlayer2", lobbyCode));
     }
 
     @Test
@@ -181,5 +229,12 @@ public class LobbyServiceTest {
         // then
         Mockito.verify(playerService, Mockito.times(2)).removePlayer(Mockito.any());
         Mockito.verify(lobbyRepository, Mockito.times(1)).delete(Mockito.any());
+    }
+
+    @Test
+    void removeLobby_noOwnerOrPlayers_success() {
+        testLobby.setOwner(null);
+        testLobby.setPlayers(null);
+        assertDoesNotThrow(() -> lobbyService.removeLobby(testLobby));
     }
 }


### PR DESCRIPTION
Added support for anonymous players. Add `playerName` as field in RequestBody. If userToken is in header, it will always try to add a user. If no userToken is present as header field, it will try to use the playerName from the RequestBody. If no name or invalid name is provided, the player gets the name Randy and gets added to the lobby.
Test it together with sopra-fs24-group-41/sopra-fs24-group-41-client#107

Closes #59 