### PR TITLE
Automatic closing of lobbies

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/Instruction.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/Instruction.java
@@ -1,5 +1,5 @@
 package ch.uzh.ifi.hase.soprafs24.constant;
 
 public enum Instruction {
-    start, stop, kick, update
+    START, STOP, KICK, UPDATE
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/Instruction.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/Instruction.java
@@ -3,7 +3,8 @@ package ch.uzh.ifi.hase.soprafs24.constant;
 public enum Instruction {
     START, STOP, KICK, UPDATE;
 
+    @Override
     public String toString() {
-        return this.name().toLowerCase();
+        return name().toLowerCase();
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/Instruction.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/Instruction.java
@@ -1,5 +1,9 @@
 package ch.uzh.ifi.hase.soprafs24.constant;
 
 public enum Instruction {
-    START, STOP, KICK, UPDATE
+    START, STOP, KICK, UPDATE;
+
+    public String toString() {
+        return this.name().toLowerCase();
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -35,8 +35,9 @@ public class LobbyController {
     private final CombinationService combinationService;
     private final APIService apiService;
 
-    private static final String LOBBY_MESSAGE_DESTINATION_BASE = "/topic/lobbies";
-    private static final String LOBBY_MESSAGE_DESTINATION_GAME = "/game";
+    private static final String MESSAGE_LOBBY_BASE = "/topic/lobbies";
+    private static final String MESSAGE_LOBBY_CODE = "/topic/lobbies/%d";
+    private static final String MESSAGE_LOBBY_GAME = "/topic/lobbies/%d/game";
 
     LobbyController(LobbyService lobbyService, UserService userService, PlayerService playerService,
                     GameService gameService, SimpMessagingTemplate messagingTemplate, CombinationService combinationService, APIService apiService) {
@@ -71,7 +72,7 @@ public class LobbyController {
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "Your user already has a lobby associated, leave it before creating a new one.");
             }
             Player player = lobbyService.createLobbyFromUser(user, lobbyPostDTO.getPublicAccess());
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE, getPublicLobbiesGetDTOList());
+            messagingTemplate.convertAndSend(MESSAGE_LOBBY_BASE, getPublicLobbiesGetDTOList());
             return DTOMapper.INSTANCE.convertEntityToPlayerJoinedDTO(player);
         }
         else {
@@ -98,7 +99,7 @@ public class LobbyController {
         else {
             player = lobbyService.joinLobbyAnonymous(playerPostDTO.getPlayerName(), lobbyCodeLong);
         }
-        messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + code, DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(player.getLobby()));
+        messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_CODE, lobbyCodeLong), DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(player.getLobby()));
         return DTOMapper.INSTANCE.convertEntityToPlayerJoinedDTO(player);
     }
 
@@ -117,10 +118,10 @@ public class LobbyController {
 
         Map<String, Boolean> updates = lobbyService.updateLobby(lobby, lobbyPutDTO);
         if (updates.get("publicAccess") || updates.get("name")) {
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE, getPublicLobbiesGetDTOList());
+            messagingTemplate.convertAndSend(MESSAGE_LOBBY_BASE, getPublicLobbiesGetDTOList());
         }
         if (updates.containsValue(true)) {
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + code,
+            messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_CODE, lobby.getCode()),
                     DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(lobby));
         }
 
@@ -133,8 +134,8 @@ public class LobbyController {
         Lobby lobby = getAuthenticatedLobby(code, playerToken);
         gameService.createNewGame(lobby);
         lobby.setStatus(LobbyStatus.INGAME);
-        messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE, getPublicLobbiesGetDTOList());
-        messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + code + LOBBY_MESSAGE_DESTINATION_GAME, new InstructionDTO(Instruction.START));
+        messagingTemplate.convertAndSend(MESSAGE_LOBBY_BASE, getPublicLobbiesGetDTOList());
+        messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_GAME, lobby.getCode()), new InstructionDTO(Instruction.START));
     }
 
     @GetMapping("/lobbies/{lobbyCode}/players/{playerId}")
@@ -156,10 +157,10 @@ public class LobbyController {
 
         if (lobbyService.allPlayersLost(lobby)) {
             lobby.setStatus(LobbyStatus.PREGAME);
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode() + LOBBY_MESSAGE_DESTINATION_GAME, new InstructionDTO(Instruction.STOP));
+            messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_GAME, lobby.getCode()), new InstructionDTO(Instruction.STOP));
         }
         else {
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode() + LOBBY_MESSAGE_DESTINATION_GAME, new InstructionDTO(Instruction.UPDATE));
+            messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_GAME, lobby.getCode()), new InstructionDTO(Instruction.UPDATE));
         }
 
         PlayerPlayedDTO playerPlayedDTO = DTOMapper.INSTANCE.convertEntityToPlayerPlayedDTO(player);
@@ -171,15 +172,16 @@ public class LobbyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removePlayerFromLobby(@PathVariable String lobbyCode, @PathVariable String playerId, @RequestHeader String playerToken) {
         Player player = getAuthenticatedPlayer(lobbyCode, playerId, playerToken);
+        long lobbyCodeLong = player.getLobby().getCode();
         if (player.getOwnedLobby() == null) {
             Lobby lobby = player.getLobby();
             playerService.removePlayer(player);
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode(), DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(lobby));
+            messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_CODE, lobby.getCode()), DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(lobby));
         }
         else {
             lobbyService.removeLobby(player.getOwnedLobby());
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE, getPublicLobbiesGetDTOList());
-            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobbyCode + LOBBY_MESSAGE_DESTINATION_GAME,
+            messagingTemplate.convertAndSend(MESSAGE_LOBBY_BASE, getPublicLobbiesGetDTOList());
+            messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_GAME, lobbyCodeLong),
                     new InstructionDTO(Instruction.KICK, "The lobby was closed by the owner"));
         }
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -37,6 +37,9 @@ public class Lobby implements Serializable {
     @Column
     private LocalDateTime startTime;
 
+    @Column
+    private LocalDateTime lastModified = LocalDateTime.now();
+
     @Column(nullable = false)
     private LobbyStatus status = LobbyStatus.PREGAME;
 
@@ -55,7 +58,11 @@ public class Lobby implements Serializable {
         this.code = code;
         this.name = name;
         this.publicAccess = false;
-        this.status = LobbyStatus.PREGAME;
+    }
+
+    @PreUpdate
+    void updateLastModified() {
+        this.lastModified = LocalDateTime.now();
     }
 
     @Override
@@ -112,6 +119,14 @@ public class Lobby implements Serializable {
 
     public void setStartTime(LocalDateTime startTime) {
     this.startTime = startTime;
+    }
+
+    public LocalDateTime getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(LocalDateTime lastModified) {
+        this.lastModified = lastModified;
     }
 
     public LobbyStatus getStatus() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -60,8 +60,9 @@ public class Lobby implements Serializable {
         this.publicAccess = false;
     }
 
+    @PrePersist
     @PreUpdate
-    void updateLastModified() {
+    public void updateLastModified() {
         this.lastModified = LocalDateTime.now();
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
@@ -38,7 +38,7 @@ public class Player implements Serializable {
     private User user;
 
     @OneToMany(mappedBy = "player", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<PlayerWord> playerWords = new HashSet<PlayerWord>();
+    private Set<PlayerWord> playerWords = new HashSet<>();
 
     @ManyToOne
     private Word targetWord;
@@ -61,6 +61,11 @@ public class Player implements Serializable {
         this.token = token;
         this.name = name;
         this.lobby = lobby;
+    }
+
+    @PreUpdate
+    void updateLobbyLastModified() {
+        lobby.updateLastModified();
     }
 
     @Override

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Player.java
@@ -63,9 +63,11 @@ public class Player implements Serializable {
         this.lobby = lobby;
     }
 
+    @PrePersist
     @PreUpdate
-    void updateLobbyLastModified() {
-        lobby.updateLastModified();
+    @PreRemove
+    public void updateLobbyLastModified() {
+        if (lobby != null) lobby.updateLastModified();
     }
 
     @Override

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -32,6 +32,8 @@ public class GameService {
     private final EnumMap<GameMode, Class<? extends Game>> gameModes = new EnumMap<>(GameMode.class);
     private final SimpMessagingTemplate messagingTemplate;
 
+    private static final String LOBBY_MESSAGE_DESTINATION_BASE = "/topic/lobbies";
+    private static final String LOBBY_MESSAGE_DESTINATION_GAME= "/game";
 
     @Autowired
     public GameService(PlayerService playerService, CombinationService combinationService, WordService wordService, SimpMessagingTemplate messagingTemplate) {
@@ -70,7 +72,8 @@ public class GameService {
 
         if (game.winConditionReached(player)) {
             lobby.setStatus(LobbyStatus.PREGAME);
-            messagingTemplate.convertAndSend("/topic/lobbies/" + lobby.getCode() + "/game", new InstructionDTO(Instruction.stop));
+            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode() + LOBBY_MESSAGE_DESTINATION_GAME,
+                    new InstructionDTO(Instruction.STOP));
         }
 
         return result;
@@ -104,13 +107,15 @@ public class GameService {
             public void run() {
                 for(int t : new int[]{10, 30, 60, 180, 300})
                     if (remainingTime == t) {
-                        messagingTemplate.convertAndSend("/topic/lobbies/" + lobby.getCode() + "/game", new TimeDTO(String.valueOf(t)));
+                        messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode() + LOBBY_MESSAGE_DESTINATION_GAME,
+                                new TimeDTO(String.valueOf(t)));
                     }
 
                 if (remainingTime <= 0) {
                     gameTimer.cancel(); // Stop the timer when time's up
                     lobby.setStatus(LobbyStatus.PREGAME);
-                    messagingTemplate.convertAndSend("/topic/lobbies/" + lobby.getCode() + "/game", new InstructionDTO(Instruction.stop));
+                    messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode() + LOBBY_MESSAGE_DESTINATION_GAME,
+                            new InstructionDTO(Instruction.STOP));
                 }
                 remainingTime -= 10; // Decrement remaining time by 10
             }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
+import ch.uzh.ifi.hase.soprafs24.constant.Instruction;
 import ch.uzh.ifi.hase.soprafs24.constant.LobbyStatus;
 import ch.uzh.ifi.hase.soprafs24.constant.PlayerStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
@@ -7,17 +8,29 @@ import ch.uzh.ifi.hase.soprafs24.entity.Player;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPutDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.websocket.InstructionDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional
@@ -28,10 +41,52 @@ public class LobbyService {
 
     private final PlayerService playerService;
 
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final PlatformTransactionManager transactionManager;
+
+    private static final String LOBBY_MESSAGE_DESTINATION_BASE = "/topic/lobbies";
+    private static final String LOBBY_MESSAGE_DESTINATION_GAME= "/game";
+
     @Autowired
-    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository, PlayerService playerService) {
+    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository, PlayerService playerService,
+                        SimpMessagingTemplate messagingTemplate, PlatformTransactionManager transactionManager) {
         this.lobbyRepository = lobbyRepository;
         this.playerService = playerService;
+        this.messagingTemplate = messagingTemplate;
+        this.transactionManager = transactionManager;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void scheduleCheckLobbyStillActive() {
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        Runnable checkLobbies = () -> {
+            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+            transactionTemplate.execute(status -> {
+                try { // TODO: set checking interval back to 30 minute and condition for deletion to 3 hours
+                    log.debug("Checking lobbies to close inactive ones");
+                    ArrayList<Lobby> allLobbies = new ArrayList<>(lobbyRepository.findAll());
+                    for (Lobby lobby : allLobbies) {
+                        long hoursDifference = ChronoUnit.MINUTES.between(lobby.getLastModified(), LocalDateTime.now());
+                        if (hoursDifference >= 1) {
+                            removeLobby(lobby);
+                            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE + "/" + lobby.getCode() + LOBBY_MESSAGE_DESTINATION_GAME,
+                                    new InstructionDTO(Instruction.KICK, "The lobby was closed due to inactivity"));
+                            log.debug("Lobby with code {} was last active on {} and was closed due to inactivity", lobby.getCode(), lobby.getLastModified());
+                        }
+                    }
+                }
+                catch (Exception e) {
+                    log.error("Error while checking lobbies", e);
+                }
+                return null;
+            });
+            messagingTemplate.convertAndSend(LOBBY_MESSAGE_DESTINATION_BASE, getPublicLobbies().stream().map(DTOMapper.INSTANCE::convertEntityToLobbyGetDTO).toList());
+        };
+
+        long initialDelay = 0;
+        long period = 30; // set to 30 seconds for testing -> deletes lobbies older than 1 minute
+        executorService.scheduleAtFixedRate(checkLobbies, initialDelay, period, TimeUnit.SECONDS);
     }
 
     public List<Lobby> getPublicLobbies() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -59,7 +59,7 @@ public class LobbyService {
 
     @EventListener(ApplicationReadyEvent.class)
     public void scheduleCheckLobbyStillActiveStartup() {
-        scheduleCheckLobbyStillActive(1, 3); // change values here to adjust timings
+        scheduleCheckLobbyStillActive(180, 30); // change values here to adjust timings
     }
 
     public void scheduleCheckLobbyStillActive(long thresholdMinutes, long periodMinutes) {
@@ -67,7 +67,7 @@ public class LobbyService {
         Runnable checkLobbies = () -> checkAndRemoveInactiveLobbies(thresholdMinutes);
 
         long initialDelay = 0;
-        executorService.scheduleAtFixedRate(checkLobbies, initialDelay, periodMinutes, TimeUnit.SECONDS);
+        executorService.scheduleAtFixedRate(checkLobbies, initialDelay, periodMinutes, TimeUnit.MINUTES);
     }
 
     public void checkAndRemoveInactiveLobbies(long thresholdMinutes) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlayerService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlayerService.java
@@ -16,7 +16,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Transactional
 public class PlayerService {
 
-    private final Logger log = LoggerFactory.getLogger(LobbyService.class);
+    private final Logger log = LoggerFactory.getLogger(PlayerService.class);
 
     private final PlayerRepository playerRepository;
 
@@ -49,6 +49,7 @@ public class PlayerService {
             player.getOwnedLobby().setOwner(null);
             player.setOwnedLobby(null);
         }
+        player.getLobby().updateLastModified();
         player.getLobby().getPlayers().remove(player);
         player.setLobby(null);
         playerRepository.delete(player);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/InstructionDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/InstructionDTO.java
@@ -19,8 +19,8 @@ public class InstructionDTO {
         this.reason = reason;
     }
 
-    public Instruction getInstruction() {
-        return instruction;
+    public String getInstruction() {
+        return instruction.toString();
     }
 
     public void setInstruction(Instruction instruction) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/InstructionDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/InstructionDTO.java
@@ -6,10 +6,17 @@ public class InstructionDTO {
 
     private Instruction instruction;
 
+    private String reason;
+
     public InstructionDTO() {}
 
     public InstructionDTO(Instruction instruction) {
         this.instruction = instruction;
+    }
+
+    public InstructionDTO(Instruction instruction, String reason) {
+        this.instruction = instruction;
+        this.reason = reason;
     }
 
     public Instruction getInstruction() {
@@ -18,5 +25,13 @@ public class InstructionDTO {
 
     public void setInstruction(Instruction instruction) {
         this.instruction = instruction;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -223,6 +223,7 @@ class LobbyServiceIntegrationTest {
         assertEquals(testPlayer.getLobby().getCode(), joinedPlayer.getLobby().getCode());
     }
 
+    @Test
     void joinLobbyAnonymous_invalidCode_throwsNotFoundException() {
         // given
         assertNull(lobbyRepository.findByCode(234));

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
@@ -38,6 +39,9 @@ class LobbyServiceTest {
 
     @Mock
     private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private PlatformTransactionManager transactionTemplate;
 
     @InjectMocks
     private LobbyService lobbyService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -12,15 +12,15 @@ import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPutDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 
 class LobbyServiceTest {
 
@@ -35,6 +35,9 @@ class LobbyServiceTest {
 
     @Mock
     private PlayerService playerService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
 
     @InjectMocks
     private LobbyService lobbyService;
@@ -85,7 +88,7 @@ class LobbyServiceTest {
         List<Lobby> foundLobbies = lobbyService.getPublicLobbies();
 
         // then
-        Mockito.verify(lobbyRepository, Mockito.times(1)).findAllByPublicAccess(Mockito.anyBoolean());
+        verify(lobbyRepository, Mockito.times(1)).findAllByPublicAccess(Mockito.anyBoolean());
         assertArrayEquals(Collections.singletonList(testLobby).toArray(), foundLobbies.toArray());
     }
 
@@ -95,7 +98,7 @@ class LobbyServiceTest {
         Lobby foundLobby = lobbyService.getLobbyByCode(1234);
 
         // then
-        Mockito.verify(lobbyRepository, Mockito.times(1)).findByCode(Mockito.anyLong());
+        verify(lobbyRepository, Mockito.times(1)).findByCode(Mockito.anyLong());
         assertEquals(testLobby, foundLobby);
     }
 
@@ -110,7 +113,7 @@ class LobbyServiceTest {
         Player createdPlayer = lobbyService.createLobbyFromUser(testUser, true);
 
         // then
-        Mockito.verify(lobbyRepository, Mockito.times(1)).saveAndFlush(Mockito.any());
+        verify(lobbyRepository, Mockito.times(1)).saveAndFlush(Mockito.any());
 
         assertEquals(testLobby.getCode(), createdPlayer.getLobby().getCode());
         assertEquals(testLobby.getName(), createdPlayer.getLobby().getName());
@@ -227,8 +230,8 @@ class LobbyServiceTest {
         lobbyService.removeLobby(testLobby);
 
         // then
-        Mockito.verify(playerService, Mockito.times(2)).removePlayer(Mockito.any());
-        Mockito.verify(lobbyRepository, Mockito.times(1)).delete(Mockito.any());
+        verify(playerService, Mockito.times(2)).removePlayer(Mockito.any());
+        verify(lobbyRepository, Mockito.times(1)).delete(Mockito.any());
     }
 
     @Test
@@ -236,5 +239,15 @@ class LobbyServiceTest {
         testLobby.setOwner(null);
         testLobby.setPlayers(null);
         assertDoesNotThrow(() -> lobbyService.removeLobby(testLobby));
+    }
+
+    @Test
+    void testCheckLobbies() {
+        testLobby.setLastModified(LocalDateTime.now().minusMinutes(10));
+        List<Lobby> lobbies = List.of(testLobby);
+        Mockito.when(lobbyRepository.findAll()).thenReturn(lobbies);
+        Mockito.doNothing().when(lobbyRepository).delete(Mockito.any());
+        lobbyService.checkAndRemoveInactiveLobbies(1);
+        verify(lobbyRepository, Mockito.times(1)).delete(testLobby);
     }
 }


### PR DESCRIPTION
Lobbies are **checked for activity every 30 minutes**. If a lobby had **no activity for at least 3 hours**, the lobby gets closed and all players are removed. 
At the same time i reworked the Instruction enum and fixed some issues pointed out by sonarcloud. InstructionDTO now has a field that can transport a reason string for the instruction. I used it to tell the client why they got kicked.

*see comment on testing*

closes #184 