### PR TITLE
Introduces new endpoint which returns the lobby status + tests

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -57,10 +57,18 @@ public class LobbyController {
     }
 
     @GetMapping("/lobbies/{code}")
+    @ResponseStatus(HttpStatus.OK)
     public LobbyGetDTO getLobbyByCode(@PathVariable String code) {
         long parsedLobbyCode = parseLobbyCode(code);
         Lobby lobby = lobbyService.getLobbyByCode(parsedLobbyCode);
         return DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(lobby);
+    }
+
+    @GetMapping("/lobbies/{code}/status")
+    public LobbyStatusGetDTO getLobbyStatus(@PathVariable String code) {
+        long parsedLobbyCode = parseLobbyCode(code);
+        Lobby lobby = lobbyService.getLobbyByCode(parsedLobbyCode);
+        return DTOMapper.INSTANCE.convertEntityToLobbyStatusGetDTO(lobby);
     }
 
     @PostMapping("/lobbies")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyStatusGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyStatusGetDTO.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs24.constant.LobbyStatus;
+
+public class LobbyStatusGetDTO {
+
+    private LobbyStatus status;
+
+    public LobbyStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LobbyStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -79,6 +79,9 @@ public interface DTOMapper {
     @Mapping(source = "players", target = "players")
     LobbyGetDTO convertEntityToLobbyGetDTO(Lobby lobby);
 
+    @Mapping(source = "status", target = "status")
+    LobbyStatusGetDTO convertEntityToLobbyStatusGetDTO(Lobby lobby);
+
     @Mapping(source = "token", target = "playerToken")
     @Mapping(source = "id", target = "playerId")
     @Mapping(source = "lobby", target = "lobby")

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -214,6 +214,22 @@ class LobbyControllerTest {
     }
 
     @Test
+    void givenLobby_validCode_thenLobbyStatusReturned() throws Exception {
+        // given
+        given(lobbyService.getLobbyByCode(Mockito.anyLong())).willReturn(testLobby);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get(String.format("/lobbies/%s/status", testLobby.getCode()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is(testLobby.getStatus().toString())));
+    }
+
+    @Test
     void createLobbyByUser_validToken_thenLobbyAndPlayerTokenReturned() throws Exception {
         // given
         testUser1.setPlayer(null);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapperTest.java
@@ -128,6 +128,17 @@ class DTOMapperTest {
         assertEquals(testLobby.getMode(), lobbyGetDTO.getMode());
     }
 
+    // tests convertEntityToLobbyStatusGetDTO
+    @Test
+    void testGetLobbyStatus_fromLobby_toLobbyStatusGetDTO_success() {
+        Lobby testLobby = new Lobby(1234, "test Lobby");
+        testLobby.setMode(GameMode.STANDARD);
+
+        LobbyStatusGetDTO lobbyStatusGetDTO = DTOMapper.INSTANCE.convertEntityToLobbyStatusGetDTO(testLobby);
+
+        assertEquals(testLobby.getStatus(), lobbyStatusGetDTO.getStatus());
+    }
+
     // tests convertEntityToPlayerJoinedDTO
     @Test
     void testCreateLobby_fromPlayerAndLobby_toPlayerJoinedDTO() {


### PR DESCRIPTION
`GET /lobbies{code}/status`
closes #222 