### PR TITLE
Target word selection balancing

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -176,7 +176,6 @@ public class LobbyController {
         Word result = gameService.play(player, words);
         messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_GAME, lobbyCodeLong),
                 new InstructionDTO(Instruction.UPDATE_PLAYERS, player.getLobby().getPlayers().stream().map(DTOMapper.INSTANCE::convertEntityToPlayerGetDTO).toList()));
-
         PlayerPlayedDTO playerPlayedDTO = DTOMapper.INSTANCE.convertEntityToPlayerPlayedDTO(player);
         playerPlayedDTO.setResultWord(DTOMapper.INSTANCE.convertEntityToWordDTO(result));
         return playerPlayedDTO;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
@@ -5,6 +5,7 @@ import org.hibernate.proxy.HibernateProxy;
 import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -21,7 +22,7 @@ public class Word implements Serializable {
     private String name;
 
     @OneToMany(mappedBy = "result")
-    private List<Combination> combinations;
+    private List<Combination> combinations = new ArrayList<>();
 
     @Column
     private Integer depth;
@@ -104,7 +105,7 @@ public class Word implements Serializable {
     }
 
     public List<Combination> getCombinations() {
-        return combinations;
+        return List.copyOf(combinations);
     }
 
     public boolean isNewlyDiscovered() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Word.java
@@ -24,10 +24,10 @@ public class Word implements Serializable {
     private List<Combination> combinations;
 
     @Column
-    private int depth;
+    private Integer depth;
 
     @Column
-    private double reachability;
+    private Double reachability;
 
     @Transient
     private boolean newlyDiscovered = false;
@@ -37,11 +37,14 @@ public class Word implements Serializable {
 
     public Word(String name) {
         setName(name);
-        this.depth = 1000;
-        this.reachability = 0.0;
     }
 
-    public Word(String name, int depth, double reachability) {
+    public Word(String name, Integer depth) {
+        setName(name);
+        this.depth = depth;
+    }
+
+    public Word(String name, Integer depth, Double reachability) {
         setName(name);
         this.depth = depth;
         this.reachability = reachability;
@@ -74,20 +77,30 @@ public class Word implements Serializable {
         this.name = name;
     }
 
-    public int getDepth() {
+    public Integer getDepth() {
         return depth;
     }
 
-    public void setDepth(int depth) {
+    public void setDepth(Integer depth) {
         this.depth = depth;
     }
 
-    public double getReachability() {
+    public void updateDepth(int depth1, int depth2) {
+        int newDepth = Math.max(depth1, depth2) + 1;
+        if (depth == null) {
+            depth = newDepth;
+        }
+        else {
+            depth = Math.min(depth, newDepth);
+        }
+    }
+
+    public Double getReachability() {
         return reachability;
     }
 
-    public void setReachability(double difficultyScore) {
-        this.reachability = difficultyScore;
+    public void setReachability(Double reachability) {
+        this.reachability = reachability;
     }
 
     public List<Combination> getCombinations() {
@@ -100,5 +113,22 @@ public class Word implements Serializable {
 
     public void setNewlyDiscovered(boolean newlyDiscovered) {
         this.newlyDiscovered = newlyDiscovered;
+    }
+
+    public void updateReachability() {
+        if (depth == 0) {
+            reachability = null;
+            return;
+        }
+
+        double newReachability = 1.0 / (1L << depth);
+
+        if (reachability == null) {
+            reachability = newReachability;
+        }
+        else {
+            reachability += newReachability;
+        }
+
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
@@ -14,7 +14,6 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 public class FiniteFusionGame extends Game {
-    private static final Integer STARTING_USES = 10;
     private float difficulty = 0.625f;
 
     public FiniteFusionGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
@@ -25,9 +24,10 @@ public class FiniteFusionGame extends Game {
     public void setupPlayers(List<Player> players) {
         setupStartingWords();
         Word targetWord = wordService.selectTargetWord(difficulty);
+        int starting_uses = targetWord.getDepth() * 2;
         for (Player player : players) {
             playerService.resetPlayer(player);
-            player.addWords(startingWords, STARTING_USES);
+            player.addWords(startingWords, starting_uses);
             player.setTargetWord(targetWord);
             player.setStatus(PlayerStatus.PLAYING);
         }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 public class FiniteFusionGame extends Game {
     private static final Integer STARTING_USES = 10;
+    private float difficulty = 0.5f;
 
     public FiniteFusionGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
         super(playerService, combinationService, wordService);
@@ -23,7 +24,7 @@ public class FiniteFusionGame extends Game {
     @Override
     public void setupPlayers(List<Player> players) {
         setupStartingWords();
-        Word targetWord = wordService.getRandomWordWithinReachability(0.1, 0.3);
+        Word targetWord = wordService.selectTargetWord(difficulty);
         for (Player player : players) {
             playerService.resetPlayer(player);
             player.addWords(startingWords, STARTING_USES);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
@@ -14,7 +14,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 public class FiniteFusionGame extends Game {
-    private float difficulty = 0.625f;
+    private float difficulty = 0.75f;
 
     public FiniteFusionGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
         super(playerService, combinationService, wordService);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGame.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public class FiniteFusionGame extends Game {
     private static final Integer STARTING_USES = 10;
-    private float difficulty = 0.5f;
+    private float difficulty = 0.625f;
 
     public FiniteFusionGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
         super(playerService, combinationService, wordService);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FusionFrenzyGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FusionFrenzyGame.java
@@ -13,7 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 public class FusionFrenzyGame extends Game {
-    private float difficulty = 0.75f;
+    private float difficulty = 0.825f;
 
     public FusionFrenzyGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
         super(playerService, combinationService, wordService);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FusionFrenzyGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/FusionFrenzyGame.java
@@ -13,6 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 public class FusionFrenzyGame extends Game {
+    private float difficulty = 0.75f;
 
     public FusionFrenzyGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
         super(playerService, combinationService, wordService);
@@ -21,7 +22,7 @@ public class FusionFrenzyGame extends Game {
     @Override
     public void setupPlayers(List<Player> players) {
         setupStartingWords();
-        Word targetWord = wordService.getRandomWordWithinReachability(0.1, 0.3);
+        Word targetWord = wordService.selectTargetWord(difficulty);
         for (Player player : players) {
             playerService.resetPlayer(player);
             player.addWords(startingWords);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/WomboComboGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/WomboComboGame.java
@@ -56,7 +56,7 @@ public class WomboComboGame extends Game {
     }
 
     void setNewTargetWord(Player player) {
-        difficulty += 0.125f;
+        difficulty += (float) (0.125f * Math.floor(player.getPoints()/10.0f));
         Word targetWord = wordService.selectTargetWord(difficulty, player.getWords());
         player.setTargetWord(targetWord);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/WomboComboGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/WomboComboGame.java
@@ -13,6 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 public class WomboComboGame extends Game {
+    private float difficulty = 0.5f;
 
     public WomboComboGame(PlayerService playerService, CombinationService combinationService, WordService wordService) {
         super(playerService, combinationService, wordService);
@@ -24,7 +25,7 @@ public class WomboComboGame extends Game {
         for (Player player : players) {
             playerService.resetPlayer(player);
             player.addWords(startingWords);
-            Word targetWord = wordService.getRandomWordWithinReachability(0.1, 0.3);
+            Word targetWord = wordService.selectTargetWord(difficulty);
             player.setTargetWord(targetWord);
             player.setStatus(PlayerStatus.PLAYING);
         }
@@ -55,22 +56,8 @@ public class WomboComboGame extends Game {
     }
 
     void setNewTargetWord(Player player) {
-        double minReachability = 0.1;
-        Word targetWord = wordService.getRandomWordWithinReachability(minReachability, 0.3);
-        int maxIter = 1000;
-        int iter = 0;
-        while (player.getWords().contains(targetWord)) {
-            minReachability *= 0.75;
-            targetWord = wordService.getRandomWordWithinReachability(minReachability, 0.3);
-            iter += 1;
-            if (iter >= maxIter) {
-                player.setTargetWord(null);
-                return;
-            }
-            if (iter >= maxIter / 2) {
-                targetWord = combinationService.generateWordWithinReachability(minReachability, 0.3);
-            }
-        }
+        difficulty += 0.125f;
+        Word targetWord = wordService.selectTargetWord(difficulty, player.getWords());
         player.setTargetWord(targetWord);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/WordRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/WordRepository.java
@@ -13,6 +13,8 @@ public interface WordRepository extends JpaRepository<Word, Long> {
 
     List<Word> findAllByReachabilityBetween(double start, double end);
 
+    List<Word> findAllByDepthBetween(int start, int end);
+
     @Query(value = "SELECT word FROM Word word WHERE word.reachability IS NOT NULL ORDER BY word.reachability DESC")
     List<Word> findAllSortedByDescendingReachability();
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/WordRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/WordRepository.java
@@ -1,9 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.repository;
 
 import ch.uzh.ifi.hase.soprafs24.entity.Word;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,6 +10,9 @@ import java.util.List;
 @Repository("wordRepository")
 public interface WordRepository extends JpaRepository<Word, Long> {
     Word findByName(String name);
-    Page<Word> findAll(Pageable pageable);
+
     List<Word> findAllByReachabilityBetween(double start, double end);
+
+    @Query(value = "SELECT word FROM Word word WHERE word.reachability IS NOT NULL ORDER BY word.reachability DESC")
+    List<Word> findAllSortedByDescendingReachability();
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CombinationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CombinationService.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs24.service;
 import ch.uzh.ifi.hase.soprafs24.entity.Combination;
 import ch.uzh.ifi.hase.soprafs24.entity.Word;
 import ch.uzh.ifi.hase.soprafs24.exceptions.CombinationNotFoundException;
+import ch.uzh.ifi.hase.soprafs24.exceptions.WordNotFoundException;
 import ch.uzh.ifi.hase.soprafs24.repository.CombinationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -18,7 +19,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 @Service
-@Transactional
+@Transactional(noRollbackFor = WordNotFoundException.class)
 public class CombinationService {
     private final CombinationRepository combinationRepository;
     private final APIService apiService;
@@ -175,6 +176,6 @@ public class CombinationService {
                 }
             }
         }
-        throw new RuntimeException("Maximum iteration exceeded");
+        throw new WordNotFoundException("within reachability");
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CombinationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CombinationService.java
@@ -33,13 +33,7 @@ public class CombinationService {
 
     @EventListener(ApplicationReadyEvent.class)
     public void setupCombinationDatabase() {
-        List<Word> startingWords = new ArrayList<Word>();
-        startingWords.add(new Word("water"));
-        startingWords.add(new Word("earth"));
-        startingWords.add(new Word("fire"));
-        startingWords.add(new Word("air"));
-
-        makeDefaultCombinations(startingWords);
+        makeDefaultCombinations();
         makeCombinations(20);
     }
 
@@ -77,15 +71,9 @@ public class CombinationService {
         catch (CombinationNotFoundException ignore) {
         }
 
-        Word word1 = combination.getWord1();
-        Word word2 = combination.getWord2();
-
-        int depth = max(word1.getDepth(), word2.getDepth()) + 1;
-        double reachability = 1.0 / (1L << depth);
-
         Word resultWord = combination.getResult();
-        resultWord.setDepth(min(resultWord.getDepth(), depth));
-        resultWord.setReachability(resultWord.getReachability() + reachability);
+        resultWord.updateDepth(combination.getWord1().getDepth(), combination.getWord2().getDepth());
+        resultWord.updateReachability();
 
         combinationRepository.saveAndFlush(combination);
         wordService.saveWord(resultWord);
@@ -125,24 +113,22 @@ public class CombinationService {
 
 
 
-    public void makeDefaultCombinations(List<Word> startingWords) {
-        for (Word word : startingWords) {
-            Word foundWord = wordService.getWord(word);
-            foundWord.setDepth(0);
-            foundWord.setReachability(1e6);
-            wordService.saveWord(foundWord);
-        }
+    public void makeDefaultCombinations() {
+        wordService.saveWord(new Word("water", 0, null));
+        wordService.saveWord(new Word("earth", 0, null));
+        wordService.saveWord(new Word("fire", 0, null));
+        wordService.saveWord(new Word("air", 0, null));
 
-        createCustomCombination(new Word("water"), new Word("water"), new Word("water"));
+        createCustomCombination(new Word("water"), new Word("water"), new Word("lake"));
         createCustomCombination(new Word("water"), new Word("earth"), new Word("mud"));
         createCustomCombination(new Word("water"), new Word("fire"), new Word("steam"));
         createCustomCombination(new Word("water"), new Word("air"), new Word("mist"));
-        createCustomCombination(new Word("earth"), new Word("earth"), new Word("earth"));
+        createCustomCombination(new Word("earth"), new Word("earth"), new Word("hill"));
         createCustomCombination(new Word("earth"), new Word("fire"), new Word("lava"));
         createCustomCombination(new Word("earth"), new Word("air"), new Word("dust"));
-        createCustomCombination(new Word("fire"), new Word("fire"), new Word("fire"));
+        createCustomCombination(new Word("fire"), new Word("fire"), new Word("wildfire"));
         createCustomCombination(new Word("fire"), new Word("air"), new Word("smoke"));
-        createCustomCombination(new Word("air"), new Word("air"), new Word("air"));
+        createCustomCombination(new Word("air"), new Word("air"), new Word("wind"));
     }
 
     public void makeCombinations(int numberOfCombinations) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CombinationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CombinationService.java
@@ -157,29 +157,24 @@ public class CombinationService {
     }
 
     public Word generateWordWithinReachability(double minReachability, double maxReachability) {
-        int maxIter = 1000;
-        int iter = 0;
-        while (true) {
-            minReachability *= 0.75;
-            maxReachability *= 1.25;
+        assert(minReachability < maxReachability);
 
-            Word word1 = wordService.getRandomWordWithinReachability(minReachability, maxReachability);
-            Word word2 = wordService.getRandomWordWithinReachability(minReachability, maxReachability);
+        int maxDepth = wordService.depthFromReachability(minReachability) + 1;  // since it's floor when casting to int
+        int minDepth = wordService.depthFromReachability(maxReachability);
 
+        for (int i = 0; i <= 100; i += 1) {
+            Word word1 = wordService.getRandomWordWithinDepth(minDepth - 1, maxDepth - 1);
+            Word word2 = wordService.getRandomWordWithinDepth(minDepth - 1, maxDepth - 1);
             try {
                 findCombination(word1, word2);
             }
             catch (CombinationNotFoundException e) {
                 Word result = createCombination(word1, word2).getResult();
-                if (minReachability <= result.getReachability() && result.getReachability() <= maxReachability) {
+                if (result.getReachability() != null && result.getReachability() >= minReachability && result.getReachability() <= maxReachability) {
                     return result;
                 }
             }
-
-            iter += 1;
-            if (iter >= maxIter) {
-                throw new RuntimeException("Maximum iteration exceeded");
-            }
         }
+        throw new RuntimeException("Maximum iteration exceeded");
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -107,7 +107,8 @@ public class GameService {
         if (result.isNewlyDiscovered()) {
             user.setDiscoveredWords(user.getDiscoveredWords() + 1);
         }
-        if (user.getRarestWordFound() == null || result.getReachability() < user.getRarestWordFound().getReachability()) {
+
+        if (user.getRarestWordFound() == null || result.getReachability() == null || result.getReachability() < user.getRarestWordFound().getReachability()) {
             user.setRarestWordFound(result);
         }
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -108,7 +108,7 @@ public class GameService {
             user.setDiscoveredWords(user.getDiscoveredWords() + 1);
         }
 
-        if (user.getRarestWordFound() == null || result.getReachability() == null || result.getReachability() < user.getRarestWordFound().getReachability()) {
+        if (user.getRarestWordFound() == null || (result.getReachability() != null && result.getReachability() < user.getRarestWordFound().getReachability())) {
             user.setRarestWordFound(result);
         }
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WordService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WordService.java
@@ -54,7 +54,7 @@ public class WordService {
         float lowerPercentage = clamp(0, desiredDifficulty - margin, 1);
         float upperPercentage = clamp(0, desiredDifficulty + margin, 1);
 
-        int startIndex = (int) Math.floor(lowerPercentage * words.size()) - 1;
+        int startIndex = (int) Math.floor(lowerPercentage * words.size());
         int endIndex = (int) Math.ceil(upperPercentage * words.size()) - 1;
 
         double maxReachability = words.get(startIndex).getReachability();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGameTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/game/FiniteFusionGameTest.java
@@ -59,8 +59,7 @@ class FiniteFusionGameTest {
     void setupPlayers_success() {
         Mockito.doNothing().when(playerService).resetPlayer(Mockito.any());
         Word testWord = new Word("testWord", 3, 0.125);
-        Mockito.doReturn(testWord)
-                .when(wordService).getRandomWordWithinReachability(Mockito.anyDouble(), Mockito.anyDouble());
+        Mockito.when(wordService.selectTargetWord(Mockito.anyFloat())).thenReturn(testWord);
 
         game.setupPlayers(players);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/game/FusionFrenzyGameTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/game/FusionFrenzyGameTest.java
@@ -88,8 +88,7 @@ class FusionFrenzyGameTest {
     void setupPlayers_success() {
         Mockito.doNothing().when(playerService).resetPlayer(Mockito.any());
         Word testWord = new Word("testWord", 3, 0.125);
-        Mockito.doReturn(testWord)
-                .when(wordService).getRandomWordWithinReachability(Mockito.anyDouble(), Mockito.anyDouble());
+        Mockito.when(wordService.selectTargetWord(Mockito.anyFloat())).thenReturn(testWord);
         game.setupPlayers(players);
 
         assertEquals(4, player1.getWords().size());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/game/WomboComboGameTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/game/WomboComboGameTest.java
@@ -57,8 +57,7 @@ class WomboComboGameTest {
     void setupPlayers_success() {
         Mockito.doNothing().when(playerService).resetPlayer(Mockito.any());
         Word testWord = new Word("testWord", 3, 0.125);
-        Mockito.doReturn(testWord)
-                .when(wordService).getRandomWordWithinReachability(Mockito.anyDouble(), Mockito.anyDouble());
+        Mockito.when(wordService.selectTargetWord(Mockito.anyFloat())).thenReturn(testWord);
         game.setupPlayers(players);
 
         assertEquals(4, player1.getWords().size());
@@ -75,7 +74,7 @@ class WomboComboGameTest {
         player1.addWord(water);
         player1.addWord(fire);
 
-        Mockito.doReturn(new Combination(water, fire, steam)).when(combinationService).getCombination(water, fire);
+        Mockito.when(combinationService.getCombination(water, fire)).thenReturn((new Combination(water, fire, steam)));
 
         game.makeCombination(player1, List.of(water, fire));
 
@@ -115,17 +114,10 @@ class WomboComboGameTest {
     }
 
     @Test
-    void setNewTargetWord_multipleIterations_success() {
-        Word commonWord = new Word("water", 0, 1e6);
-        Word commonWord1 = new Word("mud", 1, 0.5);
+    void setNewTargetWord_success() {
         Word rareWord = new Word("adamantium", 5, 0.05);
 
-        player1.addWord(commonWord);
-        player1.addWord(commonWord1);
-        Mockito.doReturn(player1.getWords().get(1))
-                .when(wordService).getRandomWordWithinReachability(AdditionalMatchers.gt(0.05), Mockito.anyDouble());
-        Mockito.doReturn(rareWord)
-                .when(wordService).getRandomWordWithinReachability(AdditionalMatchers.leq(0.05), Mockito.anyDouble());
+        Mockito.when(wordService.selectTargetWord(Mockito.anyFloat(), Mockito.any())).thenReturn(rareWord);
 
         game.setNewTargetWord(player1);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/CombinationServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/CombinationServiceIntegrationTest.java
@@ -42,16 +42,12 @@ class CombinationServiceIntegrationTest {
 
     @Test
     void getCombination_manyCombinations_success() {
-        Combination combo1 = combinationService.getCombination(new Word("fire"), new Word("water"));
-        Combination combo2 = combinationService.getCombination(new Word("fire"), new Word("water"));
-        Combination combo3 = combinationService.getCombination(new Word("fire"), new Word("earth"));
+        Combination combo1 = combinationService.getCombination(new Word("fire", 0), new Word("water", 0));
+        Combination combo2 = combinationService.getCombination(new Word("fire", 0), new Word("water", 0));
+        Combination combo3 = combinationService.getCombination(new Word("fire", 0), new Word("earth", 0));
 
-        assertEquals(combo1.getWord1().getName(), combo2.getWord1().getName());
-        assertEquals(combo1.getWord2().getName(), combo2.getWord2().getName());
-        assertEquals(combo1.getResult().getName(), combo2.getResult().getName());
-
-        assertEquals(combo1.getWord1().getName(), combo3.getWord1().getName());
-        assertNotEquals(combo1.getWord2().getName(), combo3.getWord2().getName());
+        assertEquals(combo1, combo2);
+        assertNotEquals(combo1, combo3);
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/CombinationServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/CombinationServiceIntegrationTest.java
@@ -38,6 +38,7 @@ class CombinationServiceIntegrationTest {
     public void setup() {
         combinationRepository.deleteAll();
         wordRepository.deleteAll();
+        combinationService.setupCombinationDatabase();
     }
 
     @Test
@@ -52,18 +53,23 @@ class CombinationServiceIntegrationTest {
 
     @Test
     void makeCombinations_multipleCombinations_success() {
-        ArrayList<Word> startingWords = new ArrayList<>(Arrays.asList(new Word("water"), new Word("earth"),
-                new Word("fire"), new Word("air")));
-
-        for (Word word : startingWords) {
-            Word foundWord = wordService.getWord(word);
-            foundWord.setDepth(0);
-            foundWord.setReachability(1e6);
-            wordService.saveWord(foundWord);
-        }
-
+        int beforeCount = combinationRepository.findAll().size();
         combinationService.makeCombinations(5);
+        int afterCount = combinationRepository.findAll().size();
 
-        assertEquals(5, combinationRepository.findAll().size());
+        assertEquals(beforeCount + 5, afterCount);
+    }
+
+    @Test
+    void generateWordWithinReachability_success() {
+        for (double reachability = 0.25; reachability <= 0.625; reachability += 0.125) {
+            double minReachability = reachability - 0.125;
+            double maxReachability = reachability + 0.125;
+
+            Word word = combinationService.generateWordWithinReachability(minReachability, maxReachability);
+
+            assertTrue(word.getReachability() >= minReachability);
+            assertTrue(word.getReachability() <= maxReachability);
+        }
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/CombinationServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/CombinationServiceTest.java
@@ -142,31 +142,4 @@ class CombinationServiceTest {
         Mockito.when(apiService.generateCombinationResult(Mockito.any(), Mockito.any())).thenReturn(""," ", result1.getName());
         assertEquals(result1, combinationService.generateCombinationResult(word1, word2));
     }
-
-    @Test
-    void generateWordWithinReachability_success() {
-        Word result3 = new Word("hell", 4, 0.07);
-        Combination combination3 = new Combination(word4, word4, result3);
-
-        Mockito.doReturn(word1, word2)
-                .when(wordService).getRandomWordWithinReachability(
-                        AdditionalMatchers.leq((double) 1),
-                        AdditionalMatchers.geq((double) 1));
-
-        Mockito.doReturn(word3, word4)
-                .when(wordService).getRandomWordWithinReachability(
-                        AdditionalMatchers.leq(0.05),
-                        AdditionalMatchers.geq(0.05));
-
-        Mockito.doReturn(combination1).when(combinationService).findCombination(word1, word2);
-        Mockito.doReturn(combination1).when(combinationService).findCombination(word2, word2);
-        Mockito.doThrow(CombinationNotFoundException.class).when(combinationService).findCombination(word3, word4);
-        Mockito.doThrow(CombinationNotFoundException.class).when(combinationService).findCombination(word4, word4);
-
-        Mockito.doReturn(combination2).when(combinationService).createCombination(word3, word4);
-        Mockito.doReturn(combination3).when(combinationService).createCombination(word4, word4);
-
-        Word actualResult = combinationService.generateWordWithinReachability(0.5, 2);
-        assertEquals(result3, actualResult);
-    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceIntegrationTest.java
@@ -68,8 +68,8 @@ class GameServiceIntegrationTest {
         testLobby.setStartTime(LocalDateTime.now());
         player.setLobby(testLobby);
 
-        Word word1 = new Word("water", 0, 100);
-        Word word2 = new Word("earth", 0, 100);
+        Word word1 = new Word("water", 0, 100.0);
+        Word word2 = new Word("earth", 0, 100.0);
 
         gameService.play(player, List.of(word1, word2));
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/WordServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/WordServiceTest.java
@@ -47,4 +47,13 @@ class WordServiceTest {
 
         assertEquals(testWord.getName(), foundWord.getName());
     }
+
+    @Test
+    void depthFromReachability_correct() {
+        for (int expectedDepth = 0; expectedDepth <= 10; expectedDepth++) {
+            double reachability = 1.0 / (1L << expectedDepth);
+            int actualDepth = wordService.depthFromReachability(reachability);
+            assertEquals(expectedDepth, actualDepth);
+        }
+    }
 }


### PR DESCRIPTION
Target word selection used to not be very robust, I now changed the target word selection to try to select words by relative difficulty compared to all words in the database, for example, select "one of the top 25% hardest words" rather than hard-coding some reachability. The problem was that hard-coded reachabilities quickly became outdated and not appropriate for target word selection, the bigger the database grew.

Notable changes:
- Word class now computes depth and reachability itself for cleaner code
- WordService has a selectTargetWord method that takes a difficulty (between 0 and 1) and tries to find a target word matching that difficulty. If it can't, it will try to generate a target word. If it again can't, the target word will be null. This almost never happens, especially if the database is bigger. We could add even more failsafes etc, but I thought this was a good place to stop.
- all game modes now use the new target selection method
- CombinationService now has changed default combinations for more variety. I also improved the generateWordWithinReachability method
- I fixed the tests to use the new target selection method
- I added some tests for the new method

