### PR TITLE
Only allow play moves when there is an active game in the lobby

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -177,6 +177,9 @@ public class LobbyController {
                                 @RequestHeader String playerToken, @RequestBody List<Word> words) {
         long lobbyCodeLong = parseLobbyCode(lobbyCode);
         Player player = getAuthenticatedPlayer(lobbyCode, playerId, playerToken);
+        if (player.getLobby().getStatus() != LobbyStatus.INGAME) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No active game found that you can play in. Start a game and try again.");
+        }
         Word result = gameService.play(player, words);
         messagingTemplate.convertAndSend(String.format(MESSAGE_LOBBY_GAME, lobbyCodeLong),
                 new InstructionDTO(Instruction.UPDATE_PLAYERS, player.getLobby().getPlayers().stream().map(DTOMapper.INSTANCE::convertEntityToPlayerGetDTO).toList()));

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -591,6 +591,7 @@ class LobbyControllerTest {
         words.add(new Word("fire"));
 
         testPlayer1.addWords(words);
+        testLobby.setStatus(LobbyStatus.INGAME);
 
         // when
         MockHttpServletRequestBuilder putRequest = put(String.format("/lobbies/%s/players/%s", testLobby.getCode(), testPlayer1.getId()))


### PR DESCRIPTION
Fixed case where players could play when there was no active game in the lobby. Now returns game not found exception.

Closes #241